### PR TITLE
Harden BikePress lifecycle and demo data

### DIFF
--- a/.cursor/skills/bikepress-dev/SKILL.md
+++ b/.cursor/skills/bikepress-dev/SKILL.md
@@ -160,7 +160,7 @@ Use lowercase kebab-case for `[name]`. Keep names short and meaningful.
 - Preferred zip output: that parent folder, as `wp-bikepress-v{major}.{minor}.zip`.
 - Zip **contents** must unpack to a single folder named `wp-bikepress/` (WordPress expects a plugin folder).
 - Exclude: `.git/`, `.cursor/`, `dist/`, `node_modules/`; never include secrets.
-- On Windows PowerShell, prefer Compress-Archive or a small scripted zip that preserves the plugin root folder name.
+- On Windows, **do not** use `Compress-Archive` for WordPress install zips — it adds directory-only entries (e.g. `wp-bikepress/docs/`) that cause “Could not copy file” on unpack. Build with .NET `ZipFile` / `CreateEntryFromFile` and **file entries only** (forward-slash paths, root folder `wp-bikepress/`).
 - Tell the user the full path to the zip and remind them they can upload it via WP Admin → Plugins → Add New → Upload Plugin (into the sandbox deploy path, not this development tree).
 
 ### Commit, push, PR (only after zip/docs approval)

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: OffTheKitchen
 Tags: bicycle, maintenance, bikes
 Requires at least: 4.7
 Tested up to: 6.7
-Stable tag: 4.0
+Stable tag: 5.0
 License: GPLv2 or later
 
 Track bicycles, specifications, and maintenance records, and display an interactive bike list via shortcode.
@@ -26,19 +26,40 @@ This plugin is currently only installable via a zip file.
 3. On the Add Plugin page, choose "Upload Plugin" and then "Choose File"
 4. Browse to the zip file and select it
 5. Choose "Install Now"
-6. Once the plugin is installed, activate it. The activation will create the appropriate tables and initial data.
+6. Once the plugin is installed, activate it. The activation will create the appropriate tables.
+
+= Demo / test data =
+
+By default, activation loads a small demo dataset so you can exercise the shortcode before admin CRUD is complete.
+
+To disable demo data, add this to wp-config.php before activating:
+
+`define( 'BIKEPRESS_LOAD_DEMO', false );`
+
+To force demo data on (same as the current default when undefined):
+
+`define( 'BIKEPRESS_LOAD_DEMO', true );`
+
+If you previously used hardcoded wp_* table names on a site with a custom table prefix, uninstall the plugin and activate again so tables are recreated with the correct prefix. This release does not migrate old table names automatically.
 
 == Frequently Asked Questions ==
 
 = When are the tables deleted? =
 
-The tables are deleted upon an uninstall of the plugin.
+The tables are deleted upon an uninstall of the plugin. Deactivation leaves tables and data in place.
 
 == Screenshots ==
 
 1. Screenshot of bike list rendered via shortcode.
 
 == Changelog ==
+
+= 5.0 =
+* Prefixed custom table names via $wpdb->prefix
+* Demo data gated by BIKEPRESS_LOAD_DEMO (default on when undefined)
+* Simplified demo dataset
+* Non-destructive deactivation; fuller uninstall cleanup
+* Asset enqueue cleanup; shortcode output escaping
 
 = 4.0 =
 * BikePress branding, slug, shortcode, and code identifiers

--- a/admin/class-bikepress-admin.php
+++ b/admin/class-bikepress-admin.php
@@ -13,91 +13,60 @@
 /**
  * The admin-specific functionality of the plugin.
  *
- * Defines the plugin name, version, and two examples hooks for how to
- * enqueue the admin-specific stylesheet and JavaScript.
- *
  * @package    BikePress
  * @subpackage BikePress/admin
- * @author     Your Name <email@example.com>
  */
 class BikePress_Admin {
 
 	/**
-	 * The ID of this plugin.
-	 *
 	 * @since    1.0.0
 	 * @access   private
-	 * @var      string    $plugin_name    The ID of this plugin.
+	 * @var      string
 	 */
 	private $plugin_name;
 
 	/**
-	 * The version of this plugin.
-	 *
 	 * @since    1.0.0
 	 * @access   private
-	 * @var      string    $version    The current version of this plugin.
+	 * @var      string
 	 */
 	private $version;
 
 	/**
-	 * Initialize the class and set its properties.
-	 *
-	 * @since    1.0.0
-	 * @param      string    $plugin_name    The name of this plugin.
-	 * @param      string    $version        The version of this plugin.
+	 * @since 1.0.0
+	 * @param string $plugin_name Plugin slug.
+	 * @param string $version     Plugin version.
 	 */
 	public function __construct( $plugin_name, $version ) {
-
 		$this->plugin_name = $plugin_name;
-		$this->version = $version;
-
+		$this->version     = $version;
 	}
 
 	/**
-	 * Register the stylesheets for the admin area.
+	 * Admin styles are loaded via bikepress_enqueue_admin_assets() to avoid duplicates.
 	 *
-	 * @since    1.0.0
+	 * @param string $hook Current admin page hook.
 	 */
-	public function enqueue_styles() {
-
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in BikePress_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The BikePress_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
-
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/bikepress-admin.css', array(), $this->version, 'all' );
-
+	public function enqueue_styles( $hook = '' ) {
+		// No-op: CSS handled in wp-bikepress.php for BikePress screens only.
 	}
 
 	/**
-	 * Register the JavaScript for the admin area.
+	 * Enqueue admin JS on BikePress screens only.
 	 *
-	 * @since    1.0.0
+	 * @param string $hook Current admin page hook.
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_scripts( $hook = '' ) {
+		if ( ! function_exists( 'bikepress_is_plugin_admin_screen' ) || ! bikepress_is_plugin_admin_screen( $hook ) ) {
+			return;
+		}
 
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in BikePress_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The BikePress_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
-
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/bikepress-admin.js', array( 'jquery' ), $this->version, false );
-
+		wp_enqueue_script(
+			$this->plugin_name,
+			plugin_dir_url( __FILE__ ) . 'js/bikepress-admin.js',
+			array( 'jquery' ),
+			$this->version,
+			false
+		);
 	}
-
 }

--- a/docs/versions/version-5.0.md
+++ b/docs/versions/version-5.0.md
@@ -1,0 +1,35 @@
+# Version 5.0
+
+**Status:** In progress  
+**Base:** main (after BikePress 4.0 rename)
+
+## Summary
+
+Major release focused on WordPress lifecycle hardening: prefixed table names, gated/simplified demo data, non-destructive deactivation, fuller uninstall, asset enqueue cleanup, and shortcode escaping—without expanding incomplete admin CRUD.
+
+## Changes
+
+### Features
+
+- **lifecycle-hardening** (`version5.0-feature-lifecycle-hardening`): Plugin lifecycle and public path improvements
+  - What changed:
+    - Custom tables use `$wpdb->prefix` consistently (activate, runtime constants, uninstall)
+    - Demo data simplified; loads when `BIKEPRESS_LOAD_DEMO` is undefined or `true` (set `false` in `wp-config.php` to skip)
+    - Deactivation no longer deletes `bikepress_db_version` or data
+    - Uninstall drops prefixed tables and cleans BikePress options
+    - Admin/public assets enqueued on hooks and scoped; removed file-scope enqueues and shortcode inline script tag
+    - Shortcode output escaped; plugin version set to 5.0.0
+  - Why: Safer install/activate/deactivate/uninstall behavior and a portable demo dataset while admin CRUD is still incomplete
+
+### Bugfixes
+
+_(none as a separate change)_
+
+## Install / test notes
+
+- Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v5.0.zip`
+- Unpacks to folder: `wp-bikepress/`
+- Zip is built with file entries only (no directory-only entries) so WordPress unpack on Windows succeeds
+- Prefer uninstall → install → activate for a clean schema/demo seed
+- Demo default on; disable with `define( 'BIKEPRESS_LOAD_DEMO', false );` in `wp-config.php`
+- Custom-prefix sites that still have old hardcoded `wp_*` tables should reinstall rather than expect auto-migration

--- a/includes/class-bikepress-activator.php
+++ b/includes/class-bikepress-activator.php
@@ -1,7 +1,6 @@
 <?php
-
 /**
- * Fired during plugin activation
+ * Fired during plugin activation.
  *
  * @link       http://www.offthekitchen.com
  * @since      1.0.0
@@ -11,55 +10,50 @@
  */
 
 /**
- * Fired during plugin activation.
- *
- * This class defines all code necessary to run during the plugin's activation.
+ * Defines activation behavior: schema create/upgrade and optional demo data.
  *
  * @since      1.0.0
  * @package    BikePress
  * @subpackage BikePress/includes
  * @author     John S Weeks <steve@offthekitchen.com>
  */
-class BikePress_Activator
-{
+class BikePress_Activator {
 
 	/**
-	 * Activation
+	 * Create or upgrade tables; optionally load demo data.
 	 *
-	 * This function establishes all the necessary setup during the activation of the plufgin.
-	 *
-	 * @since    1.0.0
+	 * @since 1.0.0
 	 */
-	public static function activate()
-	{
-
+	public static function activate() {
 		global $wpdb;
 
-		require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		require_once plugin_dir_path( __FILE__ ) . 'class-bikepress-tables.php';
 
-		$bikepress_db_version = '1.0';
-
+		$db_version      = '1.0';
 		$charset_collate = $wpdb->get_charset_collate();
 
-		// Create bike table
-		$sql = "CREATE TABLE IF NOT EXISTS " . BIKES_TABLE . " (
-			 id mediumint(9) NOT NULL AUTO_INCREMENT,
-			 bike_image_id mediumint(9) default 0 NOT NULL,
-			 last_update datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
-			 bike_name tinytext NOT NULL,
-			 bike_desc varchar(255) DEFAULT '' NOT NULL,
- 			 bike_make varchar(15) DEFAULT '' NOT NULL,
-  			 bike_model varchar(15) DEFAULT '' NOT NULL,
-			 serial_number varchar(30) DEFAULT '' NOT NULL,
-			 purchase_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
-			 bike_status_id mediumint(9) NOT NULL,
-			 PRIMARY KEY  (id)
-		   ) $charset_collate;";
+		$bikes_table       = bikepress_bikes_table();
+		$maintenance_table = bikepress_maintenance_table();
+		$specs_table       = bikepress_specs_table();
+		$status_table      = bikepress_status_table();
 
-		dbDelta($sql);
+		$sql = "CREATE TABLE $bikes_table (
+			id mediumint(9) NOT NULL AUTO_INCREMENT,
+			bike_image_id mediumint(9) DEFAULT 0 NOT NULL,
+			last_update datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+			bike_name tinytext NOT NULL,
+			bike_desc varchar(255) DEFAULT '' NOT NULL,
+			bike_make varchar(15) DEFAULT '' NOT NULL,
+			bike_model varchar(15) DEFAULT '' NOT NULL,
+			serial_number varchar(30) DEFAULT '' NOT NULL,
+			purchase_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+			bike_status_id mediumint(9) NOT NULL,
+			PRIMARY KEY  (id)
+		) $charset_collate;";
+		dbDelta( $sql );
 
-		// Create maintenance table
-		$sql = "CREATE TABLE IF NOT EXISTS " . MAINTENANCE_TABLE . " (
+		$sql = "CREATE TABLE $maintenance_table (
 			id mediumint(9) NOT NULL AUTO_INCREMENT,
 			bike_id mediumint(9) NOT NULL,
 			last_update datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
@@ -67,41 +61,33 @@ class BikePress_Activator
 			maintenance_desc varchar(255) DEFAULT '' NOT NULL,
 			bike_miles mediumint(9) DEFAULT 0 NOT NULL,
 			PRIMARY KEY  (id)
-			) $charset_collate;";
+		) $charset_collate;";
+		dbDelta( $sql );
 
-		dbDelta($sql);
-
-		// Create specs table
-		$sql = "CREATE TABLE IF NOT EXISTS " . SPECS_TABLE . " (
+		$sql = "CREATE TABLE $specs_table (
 			id mediumint(9) NOT NULL AUTO_INCREMENT,
 			bike_id mediumint(9) NOT NULL,
 			last_update datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
 			spec_name varchar(50) DEFAULT '' NOT NULL,
 			spec_desc varchar(50) DEFAULT '' NOT NULL,
 			PRIMARY KEY  (id)
-			) $charset_collate;";
+		) $charset_collate;";
+		dbDelta( $sql );
 
-		dbDelta($sql);
-
-		// Create status table
-		$sql = "CREATE TABLE IF NOT EXISTS " . STATUS_TABLE . " (
+		$sql = "CREATE TABLE $status_table (
 			id mediumint(9) NOT NULL AUTO_INCREMENT,
 			last_update datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
 			bike_status varchar(50) DEFAULT '' NOT NULL,
 			PRIMARY KEY  (id)
-			) $charset_collate;";
+		) $charset_collate;";
+		dbDelta( $sql );
 
-		dbDelta($sql);
+		if ( bikepress_should_load_demo() ) {
+			require_once plugin_dir_path( __FILE__ ) . 'test-data.php';
+			Test_Data::insert_test_data();
+		}
 
-		// TEST DATA
-		require_once(plugin_dir_path( __FILE__ ) . '/test-data.php');
-		Test_Data::insert_test_data();
-
-		// Prefer BikePress option key; remove legacy key if present.
 		delete_option( 'steves_bike_plugin_db_version' );
-		add_option( 'bikepress_db_version', $bikepress_db_version );
-
+		update_option( 'bikepress_db_version', $db_version );
 	}
-	
-
 }

--- a/includes/class-bikepress-deactivator.php
+++ b/includes/class-bikepress-deactivator.php
@@ -1,7 +1,6 @@
 <?php
-
 /**
- * Fired during plugin deactivation
+ * Fired during plugin deactivation.
  *
  * @link       http://www.offthekitchen.com
  * @since      1.0.0
@@ -11,9 +10,7 @@
  */
 
 /**
- * Fired during plugin deactivation.
- *
- * This class defines all code necessary to run during the plugin's deactivation.
+ * Deactivation is non-destructive: tables, demo data, and DB version remain.
  *
  * @since      1.0.0
  * @package    BikePress
@@ -23,20 +20,12 @@
 class BikePress_Deactivator {
 
 	/**
-	 * Short Description. (use period)
+	 * Run on plugin deactivation.
 	 *
-	 * Long Description.
-	 *
-	 * @since    1.0.0
+	 * @since 1.0.0
 	 */
 	public static function deactivate() {
-
-		delete_option( 'bikepress_db_version' );
-		delete_option( 'steves_bike_plugin_db_version' );
-
-		//Remove shortcodes
-		remove_shortcode( 'bikepress-bike-list' );
-
+		// Intentionally empty: deactivation must not delete data or options.
+		// Schema version and tables are removed only on uninstall.
 	}
-
 }

--- a/includes/class-bikepress-tables.php
+++ b/includes/class-bikepress-tables.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Shared table-name helpers for BikePress.
+ *
+ * @package BikePress
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Return the bikes table name with the current $wpdb prefix.
+ *
+ * @return string
+ */
+function bikepress_bikes_table() {
+	global $wpdb;
+	return $wpdb->prefix . 'bikes';
+}
+
+/**
+ * @return string
+ */
+function bikepress_maintenance_table() {
+	global $wpdb;
+	return $wpdb->prefix . 'bike_maintenance';
+}
+
+/**
+ * @return string
+ */
+function bikepress_specs_table() {
+	global $wpdb;
+	return $wpdb->prefix . 'bike_specs';
+}
+
+/**
+ * @return string
+ */
+function bikepress_status_table() {
+	global $wpdb;
+	return $wpdb->prefix . 'bike_status';
+}
+
+/**
+ * Whether demo/test data should be loaded on activation.
+ * Default ON when the constant is not defined (pre-CRUD learning default).
+ *
+ * @return bool
+ */
+function bikepress_should_load_demo() {
+	return ! defined( 'BIKEPRESS_LOAD_DEMO' ) || BIKEPRESS_LOAD_DEMO;
+}
+
+/**
+ * Whether the current admin screen belongs to BikePress.
+ *
+ * @param string $hook Current admin hook suffix.
+ * @return bool
+ */
+function bikepress_is_plugin_admin_screen( $hook ) {
+	$screens = array(
+		'toplevel_page_my-bikes',
+		'my-bikes_page_bikes-admin',
+		'my-bikes_page_specs-admin',
+		'my-bikes_page_maint-admin',
+		'my-bikes_page_data-admin',
+	);
+	return in_array( $hook, $screens, true );
+}

--- a/includes/class-bikepress.php
+++ b/includes/class-bikepress.php
@@ -70,7 +70,7 @@ class BikePress {
 		if ( defined( 'BIKEPRESS_VERSION' ) ) {
 			$this->version = BIKEPRESS_VERSION;
 		} else {
-			$this->version = '4.0.0';
+			$this->version = '5.0.0';
 		}
 		$this->plugin_name = 'bikepress';
 

--- a/includes/test-data.php
+++ b/includes/test-data.php
@@ -1,7 +1,6 @@
 <?php
-
 /**
- * Fired during plugin activation
+ * Demo / test data for BikePress activation.
  *
  * @link       http://www.offthekitchen.com
  * @since      1.0.0
@@ -11,726 +10,174 @@
  */
 
 /**
- * This class conmtrols the injection of test data
+ * Inserts a small demo dataset when enabled.
  *
- * @since      1.0.0
- * @package    BikePress
- * @subpackage BikePress/includes
- * @author     John S Weeks <steve@offthekitchen.com>
+ * @since 1.0.0
+ * @package BikePress
  */
-class Test_Data
-{
+class Test_Data {
 
 	/**
-	 * Test Data
+	 * Insert simplified demo statuses, bikes, maintenance, and specs.
 	 *
-	 * This function establishes all the necessary setup during the activation of the plugin.
-	 *
-	 * @since    1.0.0
+	 * @since 1.0.0
 	 */
-	public static function insert_test_data()
-	{
-
+	public static function insert_test_data() {
 		global $wpdb;
 
-		$status_active = 1;
-		$status_retired = 2;
-		$status_building = 3;
+		$bikes_table        = bikepress_bikes_table();
+		$maintenance_table  = bikepress_maintenance_table();
+		$specs_table        = bikepress_specs_table();
+		$status_table       = bikepress_status_table();
+		$now                = current_time( 'mysql' );
 
-		$yot_bike1_id = 1;
-		$ih_bike_id = 2;
-		$trance_bike_id = 3;
-		$ynot_bike_id = 4;
-		$sf_bike_id = 5;
-
-		// LOCAL
-		$bike1_image_id = 97;
-		$bike2_image_id = 180;
-		$bike3_image_id = 179;
-		$bike4_image_id = 309;
-		$bike5_image_id = 309;
-
-		// PROD
-/* 		$bike1_image_id = 17200;
-		$bike2_image_id = 17224;
-		$bike3_image_id = 17221;
-		$bike4_image_id = 17332;
-		$bike5_image_id = 17223; */
-
-		$charset_collate = $wpdb->get_charset_collate();
-
-		$bike_name = 'Ye Olde Townie';
-		$bike_desc = 'My old faithful bike. This guy took me on many adventures.';
-		$bike_make = 'Specialized';
-		$bike_model = 'Rockhopper';
+		// Statuses first so bikes can reference real IDs.
+		$wpdb->insert(
+			$status_table,
+			array(
+				'last_update' => $now,
+				'bike_status' => 'Active',
+			)
+		);
+		$status_active = (int) $wpdb->insert_id;
 
 		$wpdb->insert(
-			BIKES_TABLE,
+			$status_table,
 			array(
-				'last_update' => current_time('mysql'),
-				'bike_image_id' => $bike1_image_id,
-				'bike_name' => $bike_name,
-				'bike_desc' => $bike_desc,
-				'bike_make' => $bike_make,
-				'bike_model' => $bike_model,
-				'purchase_date' => date('Y-m-d', strtotime('1995-06-14')),
-				'serial_number' => 'M5GI59652',
-				'bike_status_id' => $status_retired,
+				'last_update' => $now,
+				'bike_status' => 'Retired',
+			)
+		);
+		$status_retired = (int) $wpdb->insert_id;
+
+		$wpdb->insert(
+			$status_table,
+			array(
+				'last_update' => $now,
+				'bike_status' => 'Building',
+			)
+		);
+		$status_building = (int) $wpdb->insert_id;
+
+		// Bike 1
+		$wpdb->insert(
+			$bikes_table,
+			array(
+				'last_update'     => $now,
+				'bike_image_id'   => 0,
+				'bike_name'       => 'Trail Rider',
+				'bike_desc'       => 'A reliable trail bike for weekend rides.',
+				'bike_make'       => 'Specialized',
+				'bike_model'      => 'Rockhopper',
+				'purchase_date'   => '2018-05-12 00:00:00',
+				'serial_number'   => 'DEMO-ROCK-001',
+				'bike_status_id'  => $status_active,
+			)
+		);
+		$bike1_id = (int) $wpdb->insert_id;
+
+		// Bike 2
+		$wpdb->insert(
+			$bikes_table,
+			array(
+				'last_update'     => $now,
+				'bike_image_id'   => 0,
+				'bike_name'       => 'Commuter',
+				'bike_desc'       => 'Everyday city and path commuting bike.',
+				'bike_make'       => 'Trek',
+				'bike_model'      => 'FX 2',
+				'purchase_date'   => '2020-03-01 00:00:00',
+				'serial_number'   => 'DEMO-TREK-002',
+				'bike_status_id'  => $status_active,
+			)
+		);
+		$bike2_id = (int) $wpdb->insert_id;
+
+		// Bike 3
+		$wpdb->insert(
+			$bikes_table,
+			array(
+				'last_update'     => $now,
+				'bike_image_id'   => 0,
+				'bike_name'       => 'Project Frame',
+				'bike_desc'       => 'Build in progress — demo building status.',
+				'bike_make'       => 'Surly',
+				'bike_model'      => 'Karate Monkey',
+				'purchase_date'   => '2024-01-15 00:00:00',
+				'serial_number'   => 'DEMO-SURLY-003',
+				'bike_status_id'  => $status_building ? $status_building : $status_retired,
+			)
+		);
+		$bike3_id = (int) $wpdb->insert_id;
+
+		// Maintenance (a few rows)
+		$wpdb->insert(
+			$maintenance_table,
+			array(
+				'last_update'       => $now,
+				'maintenance_date'  => '2024-06-01 00:00:00',
+				'bike_id'           => $bike1_id,
+				'maintenance_desc'  => 'New chain and cassette',
+				'bike_miles'        => 1200,
+			)
+		);
+		$wpdb->insert(
+			$maintenance_table,
+			array(
+				'last_update'       => $now,
+				'maintenance_date'  => '2025-02-10 00:00:00',
+				'bike_id'           => $bike1_id,
+				'maintenance_desc'  => 'Brake pads replaced',
+				'bike_miles'        => 1850,
+			)
+		);
+		$wpdb->insert(
+			$maintenance_table,
+			array(
+				'last_update'       => $now,
+				'maintenance_date'  => '2024-11-20 00:00:00',
+				'bike_id'           => $bike2_id,
+				'maintenance_desc'  => 'Flat tire repair',
+				'bike_miles'        => 640,
 			)
 		);
 
-		$bike_name = 'Ironhorse';
-		$bike_desc = 'Found it on the side of the road. It\'s gonna be back on the trails someday.';
-		$bike_make = 'Ironhorse';
-		$bike_model = 'Outlaw';
-
+		// Specs (a few rows)
 		$wpdb->insert(
-			BIKES_TABLE,
+			$specs_table,
 			array(
-				'last_update' => current_time('mysql'),
-				'bike_image_id' => $bike3_image_id,
-				'bike_name' => $bike_name,
-				'bike_desc' => $bike_desc,
-				'bike_make' => $bike_make,
-				'bike_model' => $bike_model,
-				'purchase_date' => date('Y-m-d', strtotime('2025-02-14')),
-				'serial_number' => '0300270',
-				'bike_status_id' => $status_building,
+				'last_update' => $now,
+				'bike_id'     => $bike1_id,
+				'spec_name'   => 'Wheel size',
+				'spec_desc'   => '29"',
 			)
 		);
-
-		$bike_name = 'In a Trance';
-		$bike_desc = 'My new mountain bike. Bought it during COVID.  It was the only one available and took some getting used to.';
-		$bike_make = 'Giant';
-		$bike_model = 'Trance';
-
 		$wpdb->insert(
-			BIKES_TABLE,
+			$specs_table,
 			array(
-				'last_update' => current_time('mysql'),
-				'bike_image_id' => $bike2_image_id,
-				'bike_name' => $bike_name,
-				'bike_desc' => $bike_desc,
-				'bike_make' => $bike_make,
-				'bike_model' => $bike_model,
-				'purchase_date' => date('Y-m-d', strtotime('2020-10-04')),
-				'serial_number' => 'G7EF06693',
-				'bike_status_id' => $status_active,
+				'last_update' => $now,
+				'bike_id'     => $bike1_id,
+				'spec_name'   => 'Drivetrain',
+				'spec_desc'   => '1x12',
 			)
 		);
-		
-		$bike_name = 'Ye New Olde Townie';
-		$bike_desc = 'A 15-year-old Rockhopper to replace my 30-year-old Rockhopper';
-		$bike_make = 'Specialized';
-		$bike_model = 'Rockhopper';
-
 		$wpdb->insert(
-			BIKES_TABLE,
+			$specs_table,
 			array(
-				'last_update' => current_time('mysql'),
-				'bike_image_id' => $bike4_image_id,
-				'bike_name' => $bike_name,
-				'bike_desc' => $bike_desc,
-				'bike_make' => $bike_make,
-				'bike_model' => $bike_model,
-				'purchase_date' => date('Y-m-d', strtotime('2024-05-10')),
-				'serial_number' => 'P7HAS1007',
-				'bike_status_id' => $status_active,
+				'last_update' => $now,
+				'bike_id'     => $bike2_id,
+				'spec_name'   => 'Tire size',
+				'spec_desc'   => '700x35c',
 			)
 		);
-
-		$bike_name = 'Super Fly';
-		$bike_desc = 'My first full-suspension mountain bike.  I bent the frame in a crash and had to retire it.';
-		$bike_make = 'Trek';
-		$bike_model = 'Super Fly';
-
 		$wpdb->insert(
-			BIKES_TABLE,
+			$specs_table,
 			array(
-				'last_update' => current_time('mysql'),
-				//'bike_image_id' => $bike5_image_id,
-				'bike_name' => $bike_name,
-				'bike_desc' => $bike_desc,
-				'bike_make' => $bike_make,
-				'bike_model' => $bike_model,
-				'purchase_date' => date('Y-m-d', strtotime('2013-08-30')),
-				'serial_number' => 'WTU024G5132H',
-				'bike_status_id' => $status_retired,
-			)
-		);
-
-        // INSERT MAINTENANCE RECORDS - Ye Olde Townie	
-
-        $maintenance_desc = 'Completely Rebuilt Drivetrain from 3x7 to 1x10';
-		$bike_miles = 1000;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2018-09-30')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced chain, brake cables and brake pads';
-		$bike_miles = 2000;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2021-01-25')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Trued back wheel';
-		$bike_miles = 2000;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2021-01-25')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced shifter cables and serviced bottom bracket';
-		$bike_miles = 3000;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2021-03-17')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced bottom bracket and chain ring';
-		$bike_miles = 4000;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2021-08-01')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced derailleur hanger and cassette';
-		$bike_miles = 4500;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2021-08-14')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced chain';
-		$bike_miles = 7602;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2022-10-26')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced shifter cable';
-		$bike_miles = 8011;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2023-12-13')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-		
-		$maintenance_desc = 'Replaced chain - SRAM 1071 10-speed';
-		$bike_miles = 8134;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2023-12-16')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Final ride - irrepairable crack in headset';
-		$bike_miles = 9192;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2025-02-08')),
-				'bike_id' => $yot_bike1_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		// INSERT MAINTENANCE RECORDS - Ironhorse
-		$maintenance_desc = 'Removed all old parts and cleaned frame';
-		$bike_miles = 0;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2024-04-09')),
-				'bike_id' => $ih_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		// INSERT MAINTENANCE RECORDS - In a Trance
-		$maintenance_desc = 'Replaced front wheel after being run over';
-		$bike_miles = 500;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2020-12-25')),
-				'bike_id' => $trance_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced rear wheel';
-		$bike_miles = 700;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2021-04-24')),
-				'bike_id' => $trance_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced brake pads and chain';
-		$bike_miles = 1000;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2021-07-20')),
-				'bike_id' => $trance_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced rear wheel (stripped freehub), brake pads and rotor';
-		$bike_miles = 1500;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2022-07-14')),
-				'bike_id' => $trance_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced chain';
-		$bike_miles = 1500;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2022-12-19')),
-				'bike_id' => $trance_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-		
-		$maintenance_desc = 'Replaced shifter cable housing';
-		$bike_miles = 3000;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2023-06-09')),
-				'bike_id' => $trance_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced brake pads';
-		$bike_miles = 3992;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2023-10-21')),
-				'bike_id' => $trance_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced chain - SRAM GX Eagle 12-speed';
-		$bike_miles = 5734;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2023-10-21')),
-				'bike_id' => $trance_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		// INSERT MAINTENANCE RECORDS - Ye New Olde Townie
-		$maintenance_desc = 'Replaced front and rear tires and chain';
-		$bike_miles = 1235;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2024-10-26')),
-				'bike_id' => $ynot_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		$maintenance_desc = 'Replaced broken spoke on rear wheel and trued wheel';
-		$bike_miles = 2538;
-
-		$wpdb->insert(
-			MAINTENANCE_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'maintenance_date' => date('Y-m-d', strtotime('2024-10-26')),
-				'bike_id' => $ynot_bike_id,
-				'maintenance_desc' => $maintenance_desc,
-				'bike_miles' => $bike_miles,
-			)
-		);
-
-		 // INSERT SPECS RECORDS - Ye Olde Townie
-		 $bike_id = 1;
-
-		 $specs_name = 'Wheel size';
-		 $specs_desc = '26 inch';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Frame size';
-		 $specs_desc = '21 inch';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Brake type';
-		 $specs_desc = 'rim brakes';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Bottom Bracket Type';
-		 $specs_desc = 'Thread Between';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Bottom Bracket Shell Width';
-		 $specs_desc = '73mm';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 // INSERT SPECS RECORDS - Ironhorse
-		 $bike_id = 2;
-		 $specs_name = 'Frame size';
-		 $specs_desc = '21.5 inch';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Bottom Bracket Type';
-		 $specs_desc = 'Thread Between';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Bottom Bracket Shell Width';
-		 $specs_desc = '68mm';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 // INSERT SPECS RECORDS - In a Trance
-		 $bike_id = 3;
-
-		 $specs_name = 'Frame size';
-		 $specs_desc = 'Large';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Wheel size';
-		 $specs_desc = '29 inch';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Brake type';
-		 $specs_desc = 'disc brakes';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $specs_name = 'Brake pads';
-		 $specs_desc = 'Shimano BP-M05-RX';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
- 		 // INSERT SPECS RECORDS - Ye New Olde Townie
-		 $bike_id = 4;
-
-		 $specs_name = 'Wheel size';
-		 $specs_desc = '26 inch';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		 $bike_id = 4;
-		 $specs_name = 'Frame size';
-		 $specs_desc = '19.5 inch';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-		 $bike_id = 4;
-		 $specs_name = 'Brake type';
-		 $specs_desc = 'rim brakes';
- 
-		 $wpdb->insert(
-			 SPECS_TABLE,
-			 array(
-				 'last_update' => current_time('mysql'),
-				 'bike_id' => $bike_id,
-				 'spec_name' => $specs_name,
-				 'spec_desc' => $specs_desc,
-			 )
-		 );
-
-		// INSERT SPECS RECORDS - Superfly
-		$specs_name = 'Wheel size';
-		$specs_desc = '29 inch';
-
-		$wpdb->insert(
-			SPECS_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'bike_id' => $sf_bike_id,
-				'spec_name' => $specs_name,
-				'spec_desc' => $specs_desc,
-			)
-		);
-
-		$specs_name = 'Frame Size';
-		$specs_desc = '19 inch - XL';
-
-		$wpdb->insert(
-			SPECS_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'bike_id' => $sf_bike_id,
-				'spec_name' => $specs_name,
-				'spec_desc' => $specs_desc,
-			)
-		);
-
-		$specs_name = 'Brake Type';
-		$specs_desc = 'Shimano - Disc';
-
-		$wpdb->insert(
-			SPECS_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'bike_id' => $sf_bike_id,
-				'spec_name' => $specs_name,
-				'spec_desc' => $specs_desc,
-			)
-		);
-
-		// INSERT STATUS RECORDS
-		$wpdb->insert(
-			STATUS_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'bike_status' => 'ACTIVE',
-			)
-		);
-
-		$wpdb->insert(
-			STATUS_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'bike_status' => 'RETIRED',
-			)
-		);
-
-		
-		$wpdb->insert(
-			STATUS_TABLE,
-			array(
-				'last_update' => current_time('mysql'),
-				'bike_status' => 'BUILDING',
+				'last_update' => $now,
+				'bike_id'     => $bike3_id,
+				'spec_name'   => 'Frame material',
+				'spec_desc'   => 'Steel',
 			)
 		);
 	}
-	
-
 }

--- a/public/class-bikepress-public.php
+++ b/public/class-bikepress-public.php
@@ -11,10 +11,7 @@
  */
 
 /**
- * The public-facing functionality of the plugin.
- *
- * Defines the plugin name, version, and two examples hooks for how to
- * enqueue the public-facing stylesheet and JavaScript.
+ * Public assets for BikePress.
  *
  * @package    BikePress
  * @subpackage BikePress/public
@@ -23,81 +20,56 @@
 class BikePress_Public {
 
 	/**
-	 * The ID of this plugin.
-	 *
 	 * @since    1.0.0
 	 * @access   private
-	 * @var      string    $plugin_name    The ID of this plugin.
+	 * @var      string
 	 */
 	private $plugin_name;
 
 	/**
-	 * The version of this plugin.
-	 *
 	 * @since    1.0.0
 	 * @access   private
-	 * @var      string    $version    The current version of this plugin.
+	 * @var      string
 	 */
 	private $version;
 
 	/**
-	 * Initialize the class and set its properties.
-	 *
-	 * @since    1.0.0
-	 * @param      string    $plugin_name    The name of the plugin.
-	 * @param      string    $version        The version of this plugin.
+	 * @since 1.0.0
+	 * @param string $plugin_name Plugin slug.
+	 * @param string $version     Plugin version.
 	 */
 	public function __construct( $plugin_name, $version ) {
-
 		$this->plugin_name = $plugin_name;
-		$this->version = $version;
-
+		$this->version     = $version;
 	}
 
 	/**
-	 * Register the stylesheets for the public-facing side of the site.
+	 * Register public styles (handle matches shortcode enqueue).
 	 *
-	 * @since    1.0.0
+	 * @since 1.0.0
 	 */
 	public function enqueue_styles() {
-
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in BikePress_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The BikePress_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
-
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/bikepress-public.css', array(), $this->version, 'all' );
-
+		wp_enqueue_style(
+			$this->plugin_name,
+			plugin_dir_url( __FILE__ ) . 'css/bikepress-public.css',
+			array(),
+			$this->version,
+			'all'
+		);
 	}
 
 	/**
-	 * Register the JavaScript for the public-facing side of the site.
+	 * Register public scripts (handle matches shortcode enqueue).
 	 *
-	 * @since    1.0.0
+	 * @since 1.0.0
 	 */
 	public function enqueue_scripts() {
-
-		/**
-		 * This function is provided for demonstration purposes only.
-		 *
-		 * An instance of this class should be passed to the run() function
-		 * defined in BikePress_Loader as all of the hooks are defined
-		 * in that particular class.
-		 *
-		 * The BikePress_Loader will then create the relationship
-		 * between the defined hooks and the functions defined in this
-		 * class.
-		 */
-
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/bikepress-public.js', array( 'jquery' ), $this->version, false );
-
+		wp_enqueue_script(
+			$this->plugin_name,
+			plugin_dir_url( __FILE__ ) . 'js/bikepress-public.js',
+			array( 'jquery' ),
+			$this->version,
+			true
+		);
 	}
-
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,11 +1,8 @@
 <?php
-
 /**
  * Fired when the plugin is uninstalled.
  *
- *
  * @link       http://www.offthekitchen.com
- *
  * @package    BikePress
  */
 
@@ -16,26 +13,21 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 global $wpdb;
 
-$bikes_table_name = $wpdb->prefix . "bikes"; 
-$maintenance_table_name = $wpdb->prefix . "bike_maintenance"; 
-$specs_table_name = $wpdb->prefix . "bike_specs"; 
-$status_table_name = $wpdb->prefix . "bike_status"; 
+$bikes_table       = $wpdb->prefix . 'bikes';
+$maintenance_table = $wpdb->prefix . 'bike_maintenance';
+$specs_table       = $wpdb->prefix . 'bike_specs';
+$status_table      = $wpdb->prefix . 'bike_status';
 
-// UNCOMMENT AFTER TESTING COMPLETE
- 
-$sql = "DROP TABLE IF EXISTS $bikes_table_name";
+// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table names are prefixed identifiers.
+$wpdb->query( "DROP TABLE IF EXISTS {$bikes_table}" );
+// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+$wpdb->query( "DROP TABLE IF EXISTS {$maintenance_table}" );
+// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+$wpdb->query( "DROP TABLE IF EXISTS {$specs_table}" );
+// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+$wpdb->query( "DROP TABLE IF EXISTS {$status_table}" );
 
-$wpdb->query($sql);
-
-$sql = "DROP TABLE IF EXISTS $maintenance_table_name";
-
-$wpdb->query($sql);
-
-$sql = "DROP TABLE IF EXISTS $specs_table_name";
-
-$wpdb->query($sql);
-
-$sql = "DROP TABLE IF EXISTS $status_table_name";
-
-$wpdb->query($sql);
-
+delete_option( 'bikepress_db_version' );
+delete_option( 'steves_bike_plugin_db_version' );
+delete_option( 'bike_name' );
+delete_option( 'bike_make' );

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -10,378 +10,336 @@
  * Plugin Name:       BikePress
  * Plugin URI:        http://www.offthekitchen.com
  * Description:       Track bicycles, specifications, and maintenance records.
- * Version:           4.0.0
+ * Version:           5.0.0
  * Author:            Off the Kitchen
  * Author URI:        http://www.offthekitchen.com
  * License:           GPL-2.0+
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       bikepress
  * Domain Path:       /languages
- * 
+ *
  */
 
 // If this file is called directly, abort.
-if (!defined('WPINC')) {
+if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-/**
- * Current plugin version.
- * Start at version 1.0.0 and use SemVer - https://semver.org
- * Rename this for your plugin and update it as you release new versions.
- */
-define('BIKEPRESS_VERSION', '4.0.0');
+define( 'BIKEPRESS_VERSION', '5.0.0' );
+
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-tables.php';
 
 /**
- * Database constants
+ * Legacy-style table constants for existing includes/partials.
+ * Values use the current $wpdb prefix.
  */
-define('BIKES_TABLE', "wp_bikes");
-define('MAINTENANCE_TABLE', "wp_bike_maintenance");
-define('SPECS_TABLE', "wp_bike_specs");
-define('STATUS_TABLE', "wp_bike_status");
+define( 'BIKES_TABLE', bikepress_bikes_table() );
+define( 'MAINTENANCE_TABLE', bikepress_maintenance_table() );
+define( 'SPECS_TABLE', bikepress_specs_table() );
+define( 'STATUS_TABLE', bikepress_status_table() );
 
-add_action('admin_menu', 'bike_maintenance_setup_menu');
-
-//Add Admin Styles
-wp_enqueue_style( 'bikepress', plugins_url( 'admin/css/bikepress-admin.css', __FILE__ ) );
-wp_enqueue_style( 'google-fonts', 'https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;700&display=swap', [], null );
-
-
-
-function bikepress_enqueue_media_uploader_scripts( $hook ) {
-    // Only enqueue the script on your specific plugin's admin page (e.g., 'toplevel_page_my-plugin-settings').
-    // You can use a conditional check here to limit where the script is loaded.
-    
-    // Ensure the media library scripts are loaded.
-    wp_enqueue_media(); 
-
-    // Enqueue your custom JavaScript file
-    wp_enqueue_script( 
-        'bikepress-admin-script', 
-        plugins_url( '/js/admin.js', __FILE__ ), // Path to your admin.js file
-        array( 'jquery' ), // Dependency on jQuery
-        '1.0', // Version number
-        true // Load in the footer
-    );
-}
-add_action( 'admin_enqueue_scripts', 'bikepress_enqueue_media_uploader_scripts' );
-
+add_action( 'admin_menu', 'bike_maintenance_setup_menu' );
+add_action( 'admin_enqueue_scripts', 'bikepress_enqueue_admin_assets' );
 add_action( 'admin_post_bike_admin_form_submit', 'handle_bike_admin_form_submission' );
-/**
- * Establish the Bike Admin menu
- */
-function bike_maintenance_setup_menu()
-{
-	global $wp_version;
 
-	// CUSTOM ICON
-	$bikes_icon = plugins_url('img/bikes-admin-icon-16.png', __FILE__);
+/**
+ * Enqueue BikePress admin CSS/fonts on plugin screens; media JS on bikes-admin only.
+ *
+ * @param string $hook Current admin page hook.
+ */
+function bikepress_enqueue_admin_assets( $hook ) {
+	if ( ! bikepress_is_plugin_admin_screen( $hook ) ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'bikepress-admin',
+		plugins_url( 'admin/css/bikepress-admin.css', __FILE__ ),
+		array(),
+		BIKEPRESS_VERSION
+	);
+	wp_enqueue_style(
+		'bikepress-google-fonts',
+		'https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;700&display=swap',
+		array(),
+		null
+	);
+
+	if ( 'my-bikes_page_bikes-admin' === $hook ) {
+		wp_enqueue_media();
+		wp_enqueue_script(
+			'bikepress-admin-script',
+			plugins_url( '/js/admin.js', __FILE__ ),
+			array( 'jquery' ),
+			BIKEPRESS_VERSION,
+			true
+		);
+	}
+}
+
+/**
+ * Establish the Bike Admin menu.
+ */
+function bike_maintenance_setup_menu() {
+	$bikes_icon = plugins_url( 'img/bikes-admin-icon-16.png', __FILE__ );
 
 	add_menu_page(
-		__('My Bikes', 'bikepress'),
-		__('My Bikes', 'bikepress'),
+		__( 'My Bikes', 'bikepress' ),
+		__( 'My Bikes', 'bikepress' ),
 		'manage_options',
 		'my-bikes',
 		'my_bikes',
 		$bikes_icon
 	);
 
-	// Add a submenu for Manage Bikes
-	add_submenu_page('my-bikes', __('Manage Bikes', 'bikepress'), __('Manage Bikes', 'bikepress'), 'manage_options', 'bikes-admin', 'bikes_admin');
-
-	// Add a submenu for Manage Specs
-	add_submenu_page('my-bikes', __('Manage Specs', 'bikepress'), __('Manage Specs', 'bikepress'), 'manage_options', 'specs-admin', 'specs_admin');
-
-	// Add a submenu for Manage Maintenance Records
-	add_submenu_page('my-bikes', __('Manage Maintenance Records', 'bikepress'), __('Manage Maintenance Records', 'bikepress'), 'manage_options', 'maint-admin', 'maint_admin');
-
-	// Add a submenu for Manage Bike Statues
-	add_submenu_page('my-bikes', __('Manage Data', 'bikepress'), __('Manage Data', 'bikepress'), 'manage_options', 'data-admin', 'data_admin');
-
-	// Add Debugging sybmenu
-	/* 	if (GIGPRESS_DEBUG) {
-		require( 'admin/debug.php' );
-		add_submenu_page( 'bikemaint', "BikeMaint &rsaquo; Debug", 'Debug', 'manage_options', "bikemaint-debug", "bikemaint_debug" );
-	} */
+	add_submenu_page( 'my-bikes', __( 'Manage Bikes', 'bikepress' ), __( 'Manage Bikes', 'bikepress' ), 'manage_options', 'bikes-admin', 'bikes_admin' );
+	add_submenu_page( 'my-bikes', __( 'Manage Specs', 'bikepress' ), __( 'Manage Specs', 'bikepress' ), 'manage_options', 'specs-admin', 'specs_admin' );
+	add_submenu_page( 'my-bikes', __( 'Manage Maintenance Records', 'bikepress' ), __( 'Manage Maintenance Records', 'bikepress' ), 'manage_options', 'maint-admin', 'maint_admin' );
+	add_submenu_page( 'my-bikes', __( 'Manage Data', 'bikepress' ), __( 'Manage Data', 'bikepress' ), 'manage_options', 'data-admin', 'data_admin' );
 }
 
+/**
+ * Stub form handler (admin CRUD still incomplete).
+ */
 function handle_bike_admin_form_submission() {
-    // 1. Verify nonce
-    if ( ! isset( $_POST['bike_admin_form_nonce_field'] ) || ! wp_verify_nonce( $_POST['bike_admin_form_nonce_field'], 'bike_admin_form_nonce_action' ) ) {
-        // Handle error (optional, you can redirect with an error message)
-        wp_die( 'Security check failed' );
-    }
+	if ( ! isset( $_POST['bike_admin_form_nonce_field'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bike_admin_form_nonce_field'] ) ), 'bike_admin_form_nonce_action' ) ) {
+		wp_die( esc_html__( 'Security check failed', 'bikepress' ) );
+	}
 
-    // Check user capabilities if necessary
-    if ( ! current_user_can( 'manage_options' ) ) {
-        wp_die( 'You do not have sufficient permissions to access this page.' );
-    }
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+	}
 
-    // 2. Sanitize and validate the data
-    $bike_name = sanitize_text_field( $_POST['bike_name'] );
-    $bike_make = sanitize_text_field( $_POST['bike_make'] );
+	$bike_name = isset( $_POST['bike_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bike_name'] ) ) : '';
+	$bike_make = isset( $_POST['bike_make'] ) ? sanitize_text_field( wp_unslash( $_POST['bike_make'] ) ) : '';
 
-    // 3. Process the data (example: save as a plugin option)
-    update_option( 'bike_name', $bike_name );
-    update_option( 'bike_make', $bike_name );
+	update_option( 'bike_name', $bike_name );
+	update_option( 'bike_make', $bike_make );
 
-    // 4. Redirect back to the form page (append a query arg for success message)
-    $redirect_url = admin_url( 'admin.php?page=bikes-admin&status=success' ); // Replace 'your_custom_plugin_page'
-    wp_redirect( esc_url_raw( $redirect_url ) );
-
-    // 5. Die after redirect
-    die();
+	$redirect_url = admin_url( 'admin.php?page=bikes-admin&status=success' );
+	wp_redirect( esc_url_raw( $redirect_url ) );
+	exit;
 }
 
 /**
- * The code that ???
+ * Admin: My Bikes hub.
  */
-function my_bikes()
-{
-	include(plugin_dir_path(__FILE__) . 'admin/partials/my-bikes-page.php');
+function my_bikes() {
+	include plugin_dir_path( __FILE__ ) . 'admin/partials/my-bikes-page.php';
 }
 
 /**
- * The code that ???
+ * Admin: manage bikes (incomplete CRUD).
  */
-function bikes_admin()
-{
-	include(plugin_dir_path(__FILE__) . 'admin/partials/bikes-admin-page.php');
-}
-
-function specs_admin()
-{
-	include(plugin_dir_path(__FILE__) . 'admin/partials/specs-admin-page.php');
+function bikes_admin() {
+	include plugin_dir_path( __FILE__ ) . 'admin/partials/bikes-admin-page.php';
 }
 
 /**
- * The code that ???
+ * Admin: specs list.
  */
-function maint_admin()
-{
-	include(plugin_dir_path(__FILE__) . 'admin/partials/maint-admin-page.php');
-}
-
-
-function data_admin()
-{
-	include(plugin_dir_path(__FILE__) . 'admin/partials/data-admin-page.php');
+function specs_admin() {
+	include plugin_dir_path( __FILE__ ) . 'admin/partials/specs-admin-page.php';
 }
 
 /**
- * The code that runs during plugin activation.
- * This action is documented in includes/class-plugin-name-activator.php
+ * Admin: maintenance list.
  */
-function activate_bikepress()
-{
-	require_once plugin_dir_path(__FILE__) . 'includes/class-bikepress-activator.php';
+function maint_admin() {
+	include plugin_dir_path( __FILE__ ) . 'admin/partials/maint-admin-page.php';
+}
+
+/**
+ * Admin: status / data list.
+ */
+function data_admin() {
+	include plugin_dir_path( __FILE__ ) . 'admin/partials/data-admin-page.php';
+}
+
+/**
+ * Activation callback.
+ */
+function activate_bikepress() {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-activator.php';
 	BikePress_Activator::activate();
 }
 
 /**
- * The code that runs during plugin deactivation.
- * This action is documented in includes/class-plugin-name-deactivator.php
+ * Deactivation callback.
  */
-function deactivate_bikepress()
-{
-	require_once plugin_dir_path(__FILE__) . 'includes/class-bikepress-deactivator.php';
+function deactivate_bikepress() {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-deactivator.php';
 	BikePress_Deactivator::deactivate();
 }
 
-function save_output_buffer_to_file()
-{
-	file_put_contents(
-		ABSPATH . 'wp-content/plugins/activation_output_buffer.html'
-		,
-		ob_get_contents()
-	);
-}
-
 /**
- * This function creates content for the bike list shortcode
+ * Shortcode: interactive bike list.
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
  */
-function bikepress_bike_list($atts)
-{
-	require_once plugin_dir_path(__FILE__) . 'includes/class-bike.php';
-
+function bikepress_bike_list( $atts ) {
 	global $wpdb;
 
-	$bike_plugin_url = plugin_dir_url(__FILE__);
+	$bike_plugin_url = plugin_dir_url( __FILE__ );
+	$bikes_table     = BIKES_TABLE;
+	$status_table    = STATUS_TABLE;
+	$maint_table     = MAINTENANCE_TABLE;
+	$specs_table     = SPECS_TABLE;
 
-	$aBikes = $wpdb->get_results("SELECT " . BIKES_TABLE . ".*, " . STATUS_TABLE . ".bike_status FROM " . BIKES_TABLE . "  INNER JOIN " . STATUS_TABLE . " ON " . BIKES_TABLE . ".bike_status_id = " . STATUS_TABLE . ".id");
-	$aMaintenance = $wpdb->get_results("SELECT * FROM " . MAINTENANCE_TABLE);
-	$aSpecs = $wpdb->get_results("SELECT * FROM " . SPECS_TABLE);
+	// Ensure public assets load when the shortcode renders.
+	wp_enqueue_style( 'bikepress' );
+	wp_enqueue_script( 'bikepress' );
 
-	// BIKES LIST SECTION
-	$Content = '<section id="bike-list" class="bike-section fade-in">';
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table names are trusted prefixed identifiers.
+	$aBikes = $wpdb->get_results(
+		"SELECT {$bikes_table}.*, {$status_table}.bike_status
+		FROM {$bikes_table}
+		INNER JOIN {$status_table}
+			ON {$bikes_table}.bike_status_id = {$status_table}.id"
+	);
+
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$aMaintenance = $wpdb->get_results( "SELECT * FROM {$maint_table}" );
+	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	$aSpecs = $wpdb->get_results( "SELECT * FROM {$specs_table}" );
+
+	$last_bike_id = 0;
+	if ( ! empty( $aBikes ) ) {
+		$last_bike    = end( $aBikes );
+		$last_bike_id = isset( $last_bike->id ) ? absint( $last_bike->id ) : 0;
+		reset( $aBikes );
+	}
+
+	$default_img = esc_url( $bike_plugin_url . 'img/default-bike.jpg' );
+	$icon_maint  = esc_url( $bike_plugin_url . 'img/icon-maint.png' );
+	$icon_specs  = esc_url( $bike_plugin_url . 'img/icon-specs.png' );
+	$icon_bikes  = esc_url( $bike_plugin_url . 'img/icon-bikes.png' );
+
+	$Content  = '<section id="bike-list" class="bike-section fade-in">';
 	$Content .= '<h1 class="bike-list-title">BIKES</h1>';
-	$Content .= '</h1>';
-	foreach ($aBikes as $oBike) {
+
+	foreach ( $aBikes as $oBike ) {
+		$bike_id   = absint( $oBike->id );
+		$bike_name = esc_html( $oBike->bike_name );
+		$bike_js   = esc_js( $oBike->bike_name );
+
 		$Content .= '<article class="bike bike-data">';
-		$image_attributes = wp_get_attachment_image_src($oBike->bike_image_id);
-		$sImageTag = '';
-		if ($image_attributes) {
-			$sImageTag = "<img src=\"{$image_attributes[0]}\" width=\"{$image_attributes[1]}\" height=\"{$image_attributes[2]}\" class=\"bike-image\" />";
+
+		$image_attributes = wp_get_attachment_image_src( absint( $oBike->bike_image_id ) );
+		if ( $image_attributes ) {
+			$Content .= sprintf(
+				'<img src="%s" width="%d" height="%d" class="bike-image" alt="%s" />',
+				esc_url( $image_attributes[0] ),
+				absint( $image_attributes[1] ),
+				absint( $image_attributes[2] ),
+				$bike_name
+			);
 		} else {
-			$sImageTag = "<img src=\"{$bike_plugin_url}img/default-bike.jpg\" class=\"bike-image\" />";
+			$Content .= '<img src="' . $default_img . '" class="bike-image" alt="' . $bike_name . '" />';
 		}
-		$Content .= $sImageTag;
+
 		$Content .= '<div class="bike-info">';
 		$Content .= '<div class="bike-header">';
-		$Content .= "<h2 class=\"bike-title\">{$oBike->bike_name}</h2>";
+		$Content .= '<h2 class="bike-title">' . $bike_name . '</h2>';
 		$Content .= '<div class="icons-wrapper">';
-		$Content .= "<a href=\"javascript:void(0);\" onclick=\"showSection('maintenance', {$oBike->id}, '{$oBike->bike_name}');\">";
-		$Content .= "<img src=\"{$bike_plugin_url}img/icon-maint.png\" class=\"bike-icon\" />";
-		$Content .= '<p class="icon-subtext">Matinenance</p>';
+		$Content .= '<a href="javascript:void(0);" onclick="showSection(\'maintenance\', ' . $bike_id . ', \'' . $bike_js . '\');">';
+		$Content .= '<img src="' . $icon_maint . '" class="bike-icon" alt="" />';
+		$Content .= '<p class="icon-subtext">Maintenance</p>';
 		$Content .= '</a>';
-		$Content .= "<a href=\"javascript:void(0);\" onclick=\"showSection('specs', {$oBike->id}, '{$oBike->bike_name}');\">";
-		$Content .= "<img src=\"{$bike_plugin_url}img/icon-specs.png\" class=\"bike-icon\" />";
+		$Content .= '<a href="javascript:void(0);" onclick="showSection(\'specs\', ' . $bike_id . ', \'' . $bike_js . '\');">';
+		$Content .= '<img src="' . $icon_specs . '" class="bike-icon" alt="" />';
 		$Content .= '<p class="icon-subtext">Specs</p>';
 		$Content .= '</a>';
-		$Content .= '</div>';
-		$Content .= '</div>';
+		$Content .= '</div></div>';
 		$Content .= '<div class="bike-specs">';
-		$Content .= "<div class=\"bike-make bike-detail\"><b>MAKE:</b> {$oBike->bike_make}</div>";
-		$Content .= "<div class=\"bike-model bike-detail\"><b>MODEL:</b> {$oBike->bike_model} </div>";
-		$Content .= "<div class=\"bike-status bike-detail\"><b>STATUS:</b> {$oBike->bike_status} </div>";
+		$Content .= '<div class="bike-make bike-detail"><b>MAKE:</b> ' . esc_html( $oBike->bike_make ) . '</div>';
+		$Content .= '<div class="bike-model bike-detail"><b>MODEL:</b> ' . esc_html( $oBike->bike_model ) . '</div>';
+		$Content .= '<div class="bike-status bike-detail"><b>STATUS:</b> ' . esc_html( $oBike->bike_status ) . '</div>';
 		$Content .= '</div>';
-		$Content .= '<div class="bike-data">';
-		$Content .= "<div class=\"bike-desc\">{$oBike->bike_desc}</div>";
-		$Content .= '</div>';
-		$Content .= '</div>';
-		$Content .= '</article>';
+		$Content .= '<div class="bike-data"><div class="bike-desc">' . esc_html( $oBike->bike_desc ) . '</div></div>';
+		$Content .= '</div></article>';
 	}
 	$Content .= '</section>';
 
-	// MAINTENANCE SECTION
+	// Maintenance section.
 	$Content .= '<section id="maintenance-log" class="bike-section fade-in">';
 	$Content .= '<h1 class="maintenance-log-title">MAINTENANCE LOG</h1>';
 	$Content .= '<h2 id="maintenance-log-bike-name"></h2>';
-	$Content .= '<div class="maintenance-header bike-section-header">';
-	$Content .= '<div class="icons-wrapper">';
-	$Content .= "<a href=\"javascript:void(0);\" onclick=\"showSection('bikes', 0, '')\">";
-	$Content .= "<img src=\"{$bike_plugin_url}img/icon-bikes.png\" class=\"bike-icon\" />";
-	$Content .= '<p class="icon-subtext">Bike List</p>';
-	$Content .= '</a>';
-	$Content .= "<a href=\"javascript:void(0);\" onclick=\"showSection('specs', {$oBike->id}, bikeName)\" id=\"maint-to-specs-link\">";
-	$Content .= "<img src=\"{$bike_plugin_url}img/icon-specs.png\" class=\"bike-icon\" />";
-	$Content .= '<p class="icon-subtext">Specs</p>';
-	$Content .= '</a>';
-	$Content .= '</div>';
-	$Content .= '</div>';
+	$Content .= '<div class="maintenance-header bike-section-header"><div class="icons-wrapper">';
+	$Content .= '<a href="javascript:void(0);" onclick="showSection(\'bikes\', 0, \'\')">';
+	$Content .= '<img src="' . $icon_bikes . '" class="bike-icon" alt="" /><p class="icon-subtext">Bike List</p></a>';
+	$Content .= '<a href="javascript:void(0);" onclick="showSection(\'specs\', ' . $last_bike_id . ', bikeName)" id="maint-to-specs-link">';
+	$Content .= '<img src="' . $icon_specs . '" class="bike-icon" alt="" /><p class="icon-subtext">Specs</p></a>';
+	$Content .= '</div></div>';
 
 	$Content .= '<div class="maintenance-entries bike-entries">';
-	$Content .= '<header class="maintenance-entry-headers entry-headers">';
-	$Content .= '<div class="col">DATE</div><div class="col">MAINT</div><div class="col">MILES</div>';
-	$Content .= '</header>';
-	// Purchase Date Row
-	foreach ($aBikes as $oBike) {
-		$dateArray = date_parse($oBike->purchase_date);
-		$formattedDate = "{$dateArray['year']}-{$dateArray['month']}-{$dateArray['day']}";
-		$Content .= "<div class=\"entry-record maintenance-entry row bike-{$oBike->id}\">";
-		$Content .= "<div class=\"maint-date col\">{$formattedDate}</div>";
-		$Content .= "<div class=\"maint-desc col\">Purchased</div>";
-		$Content .= "<div class=\"bike-miles col\">0</div>";
-		$Content .= '</div>';
-	}
-	foreach ($aMaintenance as $oMaintRecord) {
-		$dateArray = date_parse($oMaintRecord->maintenance_date);
-		$formattedDate = "{$dateArray['year']}-{$dateArray['month']}-{$dateArray['day']}";
+	$Content .= '<header class="maintenance-entry-headers entry-headers"><div class="col">DATE</div><div class="col">MAINT</div><div class="col">MILES</div></header>';
 
-		$Content .= "<div class=\"entry-record maintenance-entry row bike-{$oMaintRecord->bike_id}\">";
-		$Content .= "<div class=\"maint-date col\">{$formattedDate}</div>";
-		$Content .= "<div class=\"maint-desc col\">{$oMaintRecord->maintenance_desc}</div>";
-		$Content .= "<div class=\"bike-miles col\">{$oMaintRecord->bike_miles}</div>";
-		$Content .= '</div>';
+	foreach ( $aBikes as $oBike ) {
+		$date_array     = date_parse( $oBike->purchase_date );
+		$formatted_date = esc_html( sprintf( '%d-%d-%d', $date_array['year'], $date_array['month'], $date_array['day'] ) );
+		$Content       .= '<div class="entry-record maintenance-entry row bike-' . absint( $oBike->id ) . '">';
+		$Content       .= '<div class="maint-date col">' . $formatted_date . '</div>';
+		$Content       .= '<div class="maint-desc col">Purchased</div>';
+		$Content       .= '<div class="bike-miles col">0</div></div>';
 	}
-	$Content .= '<div class="no-records">NO RECORDS FOUND</div>';
-	$Content .= '</div>';
-	$Content .= '</section>';
 
-	// SPECS SECTION
+	foreach ( $aMaintenance as $oMaintRecord ) {
+		$date_array     = date_parse( $oMaintRecord->maintenance_date );
+		$formatted_date = esc_html( sprintf( '%d-%d-%d', $date_array['year'], $date_array['month'], $date_array['day'] ) );
+		$Content       .= '<div class="entry-record maintenance-entry row bike-' . absint( $oMaintRecord->bike_id ) . '">';
+		$Content       .= '<div class="maint-date col">' . $formatted_date . '</div>';
+		$Content       .= '<div class="maint-desc col">' . esc_html( $oMaintRecord->maintenance_desc ) . '</div>';
+		$Content       .= '<div class="bike-miles col">' . esc_html( (string) $oMaintRecord->bike_miles ) . '</div></div>';
+	}
+
+	$Content .= '<div class="no-records">NO RECORDS FOUND</div></div></section>';
+
+	// Specs section.
 	$Content .= '<section id="specs-list" class="bike-section fade-in">';
 	$Content .= '<h1 class="specs-list-title">SPECIFICATIONS</h1>';
 	$Content .= '<h2 id="specs-list-bike-name"></h2>';
-	$Content .= '<div class="specs-header bike-section-header">';
-	$Content .= '<div class="icons-wrapper">';
-	$Content .= "<a href=\"javascript:void(0);\" onclick=\"showSection('bikes', 0, '');\">";
-	$Content .= "<img src=\"{$bike_plugin_url}img/icon-bikes.png\" class=\"bike-icon\" />";
-	$Content .= '<p class="icon-subtext">Bike List</p>';
-	$Content .= "<a href=\"javascript:void(0);\" onclick=\"showSection('specs', {$oBike->id}, bikeName);\"  id=\"specs-to-maint-link\">";
-	$Content .= "<img src=\"{$bike_plugin_url}img/icon-maint.png\" class=\"bike-icon\" />";
-	$Content .= '<p class="icon-subtext">Matinenance</p>';
-	$Content .= '</a>';
-	$Content .= '</div>';
-	$Content .= '</div>';
+	$Content .= '<div class="specs-header bike-section-header"><div class="icons-wrapper">';
+	$Content .= '<a href="javascript:void(0);" onclick="showSection(\'bikes\', 0, \'\');">';
+	$Content .= '<img src="' . $icon_bikes . '" class="bike-icon" alt="" /><p class="icon-subtext">Bike List</p></a>';
+	$Content .= '<a href="javascript:void(0);" onclick="showSection(\'maintenance\', ' . $last_bike_id . ', bikeName);" id="specs-to-maint-link">';
+	$Content .= '<img src="' . $icon_maint . '" class="bike-icon" alt="" /><p class="icon-subtext">Maintenance</p></a>';
+	$Content .= '</div></div>';
 
 	$Content .= '<div class="spec-entries bike-entries">';
-	$Content .= '<header class="spec-entry-headers entry-headers">';
-	$Content .= '<div class="col">NAME</div><div class="col">DESC</div>';
-	$Content .= '</header>';
-	//Serial Number Row
-	foreach ($aBikes as $oBike) {
-		$Content .= "<div class=\"entry-record spec-entry row bike-{$oBike->id}\">";
-		$Content .= "<div class=\"spec-name col\">Serial Number</div>";
-		$Content .= "<div class=\"spec-desc col\">{$oBike->serial_number}</div>";
-		$Content .= '</div>';
-	}
-	foreach ($aSpecs as $oSpecRecord) {
-		$Content .= "<div class=\"entry-record spec-entry row bike-{$oSpecRecord->bike_id}\">";
-		$Content .= "<div class=\"spec-name col\">{$oSpecRecord->spec_name}</div>";
-		$Content .= "<div class=\"spec-desc col\">{$oSpecRecord->spec_desc}</div>";
-		$Content .= '</div>';
+	$Content .= '<header class="spec-entry-headers entry-headers"><div class="col">NAME</div><div class="col">DESC</div></header>';
+
+	foreach ( $aBikes as $oBike ) {
+		$Content .= '<div class="entry-record spec-entry row bike-' . absint( $oBike->id ) . '">';
+		$Content .= '<div class="spec-name col">Serial Number</div>';
+		$Content .= '<div class="spec-desc col">' . esc_html( $oBike->serial_number ) . '</div></div>';
 	}
 
-	$Content .= '</div>';
-	$Content .= '<div class="no-records">NO RECORDS FOUND</div>';
-	$Content .= '</section>';
+	foreach ( $aSpecs as $oSpecRecord ) {
+		$Content .= '<div class="entry-record spec-entry row bike-' . absint( $oSpecRecord->bike_id ) . '">';
+		$Content .= '<div class="spec-name col">' . esc_html( $oSpecRecord->spec_name ) . '</div>';
+		$Content .= '<div class="spec-desc col">' . esc_html( $oSpecRecord->spec_desc ) . '</div></div>';
+	}
 
-
-	$Content .= "<script type=\"text/javascript\" src=\"{$bike_plugin_url}public/js/bikepress-public.js\"></script>";
+	$Content .= '</div><div class="no-records">NO RECORDS FOUND</div></section>';
 
 	return $Content;
 }
 
-//Add all the shortcodes
-add_shortcode('bikepress-bike-list', 'bikepress_bike_list');
+add_shortcode( 'bikepress-bike-list', 'bikepress_bike_list' );
 
-// During activation send any output to a file
-add_action('activated_plugin', 'save_output_buffer_to_file');
+register_activation_hook( __FILE__, 'activate_bikepress' );
+register_deactivation_hook( __FILE__, 'deactivate_bikepress' );
 
-register_activation_hook(__FILE__, 'activate_bikepress');
-register_deactivation_hook(__FILE__, 'deactivate_bikepress');
+require plugin_dir_path( __FILE__ ) . 'includes/class-bikepress.php';
 
 /**
- * The core plugin class that is used to define internationalization,
- * admin-specific hooks, and public-facing site hooks.
+ * Boot the plugin.
  */
-require plugin_dir_path(__FILE__) . 'includes/class-bikepress.php';
-
-/**
- * Begins execution of the plugin.
- *
- * Since everything within the plugin is registered via hooks,
- * then kicking off the plugin from this point in the file does
- * not affect the page life cycle.
- *
- * @since    1.0.0
- */
-function run_bikepress()
-{
-
+function run_bikepress() {
 	$plugin = new BikePress();
 	$plugin->run();
-
 }
-/**
- * This function adds the custom styles for the plugin to the WP styling framework
- */
-function bikepress_enqueue_styles()
-{
-	wp_enqueue_style('bikepress_style', plugin_dir_url(__FILE__) . 'public/css/bikepress-public.css');
-}
-
-// Add the custom styles
-add_action('wp_enqueue_scripts', 'bikepress_enqueue_styles');
 
 run_bikepress();


### PR DESCRIPTION
## Summary
- Change type: Feature
- Version line: version5.0
- Prefixed custom tables via `$wpdb->prefix`; aligned uninstall
- Simplified demo data gated by `BIKEPRESS_LOAD_DEMO` (default on when undefined)
- Non-destructive deactivation; fuller option/table cleanup on uninstall
- Asset enqueue cleanup; shortcode escaping; install zip built without directory-only entries

## Test plan
- [ ] Install `wp-bikepress-v5.0.zip` on sandbox WP (unpack succeeds on Windows)
- [ ] Activate with demo default on — shortcode shows sample bikes
- [ ] `define('BIKEPRESS_LOAD_DEMO', false);` + reinstall — tables exist, no demo rows
- [ ] Deactivate — data and `bikepress_db_version` remain
- [ ] Uninstall — tables/options removed

## Notes
- Merging will be handled outside GitHub for now unless requested otherwise.