### PR TITLE
Add Phase 1 Manage Bikes admin CRUD

### DIFF
--- a/admin/partials/bikes-admin-page.php
+++ b/admin/partials/bikes-admin-page.php
@@ -1,323 +1,262 @@
 <?php
 /**
- * Bike Maintenance Page
+ * Manage Bikes — list, add, edit, delete (Phase 1 CRUD).
+ *
+ * @package BikePress
  */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+}
 
 global $wpdb;
 
-$bike_plugin_url = WP_PLUGIN_DIR . '/wp-bikepress';
+$action  = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : 'list';
+$bike_id = isset( $_GET['bike_id'] ) ? absint( $_GET['bike_id'] ) : 0;
 
-// Data
-$mode = 'new';
-$bikeId = 0;
-$bikeName = '';
-$bikeMake = '';
-$bikeModel = '';
-$serialNumber = '';
-$bikeStatusId = '';
-$bikeImageId = 0;
-$bikeDescription = '';
-
-if (isset($_REQUEST['bike_id']) && $_REQUEST['bike_id'] != "") {
-    $mode = 'editting';
-    $bikeId = $_REQUEST['bike_id'];
-    $thisBike = $wpdb->get_results("SELECT * FROM " . BIKES_TABLE . " WHERE id = " . $bikeId);
-}
-    $bikeName = $_POST['bike-name'];
-    $bikeMake = $_POST['bike-make'];
-// --- ADDING OR UPDATING ---
-if (isset($_POST["update"]) || isset($_POST["add"])) {
-    echo "<h1>UPDATE OR add</h1>";
-    $mode =- 'editting';
-    $bikeId = $_POST['bike-id'];
-    $bikeName = $_POST['bike-name'];
-    $bikeMake = $_POST['bike-make'];
-    $bikeModel = $_POST['bike-model'];
-    $serialNumber = $_POST['serial-number'];
-    $bikeStatusId = $_POST['bike-status'];
-    $bikeImageId = $_POST['bike-image-id'];
-    $bikeDescription = $_POST['bike-desc'];
+if ( ! in_array( $action, array( 'list', 'new', 'edit', 'delete' ), true ) ) {
+	$action = 'list';
 }
 
-// UPDATE BIKE
-if (isset($_POST['update'])) {
-    echo "<h1>UPDATE/h1>";
-    $data_to_update = array(
-    'bike_name' => $bikeName,
-    'bike_make' => $bikeMake,
-    'bike_model' => $bikeModel,
-    'serial_number' => $serialNumber,
-    'bike_status' => $bikeStatus,
-    'bike_image_id' => $bikeImageId,
-    'bike_desc' => $bikeDescription
-    );
+$list_url = admin_url( 'admin.php?page=bikes-admin' );
+$new_url  = admin_url( 'admin.php?page=bikes-admin&action=new' );
 
-    $where_condition = array(
-    'ID' => $bikeId
+$statuses = $wpdb->get_results( 'SELECT id, bike_status FROM ' . STATUS_TABLE . ' ORDER BY bike_status ASC' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+$bike = null;
+if ( 'edit' === $action || 'delete' === $action ) {
+	if ( $bike_id <= 0 ) {
+		$action = 'list';
+	} else {
+		$bike = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . BIKES_TABLE . ' WHERE id = %d', $bike_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		if ( ! $bike ) {
+			$action = 'list';
+			$bike_id = 0;
+		}
+	}
+}
+
+$notice = isset( $_GET['bikepress_notice'] ) ? sanitize_key( wp_unslash( $_GET['bikepress_notice'] ) ) : '';
+$notice_messages = array(
+	'bike_created'         => array( 'success', __( 'Bike created.', 'bikepress' ) ),
+	'bike_updated'         => array( 'success', __( 'Bike updated.', 'bikepress' ) ),
+	'bike_deleted'         => array( 'success', __( 'Bike and related specs/maintenance deleted.', 'bikepress' ) ),
+	'bike_save_error'      => array( 'error', __( 'Could not save the bike.', 'bikepress' ) ),
+	'bike_delete_error'    => array( 'error', __( 'Could not delete the bike.', 'bikepress' ) ),
+	'bike_name_required'   => array( 'error', __( 'Bike name is required.', 'bikepress' ) ),
+	'bike_status_required' => array( 'error', __( 'Please choose a status.', 'bikepress' ) ),
 );
 
-$data_formats = array(
-    '%s', // Format for 'post_title'
-    '%s'  // Format for 'post_content'
-);
+$default_image = plugins_url( 'img/default-bike.jpg', dirname( dirname( __FILE__ ) ) . '/wp-bikepress.php' );
 
-$where_formats = array(
-    '%d'  // Format for 'ID'
-);
+$form_bike_id        = 0;
+$form_name           = '';
+$form_make           = '';
+$form_model          = '';
+$form_serial         = '';
+$form_status_id      = 0;
+$form_desc           = '';
+$form_image_id       = 0;
+$form_purchase_date  = '';
 
-$updated = $wpdb->update(
-    BIKES_TABLE,
-    $data_to_update,
-    $where_condition,
-    $data_formats,
-    $where_formats
-);
-
-if ( false === $updated ) {
-    // Handle error
-    echo "An error occurred during the update.";
-} else {
-    // Success, potentially 0 rows updated if values were the same
-    echo "Rows updated: " . $updated;
+if ( $bike ) {
+	$form_bike_id       = absint( $bike->id );
+	$form_name          = $bike->bike_name;
+	$form_make          = $bike->bike_make;
+	$form_model         = $bike->bike_model;
+	$form_serial        = $bike->serial_number;
+	$form_status_id     = absint( $bike->bike_status_id );
+	$form_desc          = $bike->bike_desc;
+	$form_image_id      = absint( $bike->bike_image_id );
+	if ( ! empty( $bike->purchase_date ) && '0000-00-00 00:00:00' !== $bike->purchase_date ) {
+		$form_purchase_date = gmdate( 'Y-m-d', strtotime( $bike->purchase_date ) );
+	}
 }
 
+$preview_url = $default_image;
+if ( $form_image_id > 0 ) {
+	$src = wp_get_attachment_image_src( $form_image_id, 'medium' );
+	if ( $src ) {
+		$preview_url = $src[0];
+	}
 }
-
-$aBikes = $wpdb->get_results("SELECT * FROM " . BIKES_TABLE);
-$aStatuses = $wpdb->get_results("SELECT * FROM " . STATUS_TABLE);
-
-// Should really check if ercord was found 
-if ($bikeId && $bikeId > 0) {
-    $bikeName = $thisBike[0]->bike_name;
-    $bikeMake = $thisBike[0]->bike_make;
-    $bikeModel = $thisBike[0]->bike_model;
-    $serialNumber = $thisBike[0]->serial_number;
-    $bikeStatus = $thisBike[0]->bike_status;
-    $bikeImageId = $thisBike[0]->bike_image_id;
-    $bikeDescription = $thisBike[0]->bike_desc;
-    $image_attributes = wp_get_attachment_image_src($bikeImageId);
-    $imageTag = '';
-    if ($image_attributes) {
-        $imageTag = "<img id=\"bike-image\" src=\"{$image_attributes[0]}\" width=\"{$image_attributes[1]}\" height=\"{$image_attributes[2]}\" class=\"bike-image\" />";
-    } else {
-        $imageTag = "<img id=\"bike-image\" src=\"{$bike_plugin_url}img/default-bike.jpg\" class=\"bike-image\" />";
-    }
-}
-
-
 ?>
-<div class="main-container">
-    <?php include(plugin_dir_path(__FILE__) . 'bike-admin-header.php'); ?>
-    <h1>MANAGE BIKES</h1>
-    <main class="main-content">
-        <form id="bikepress-bike-form" action="<?php echo esc_url( admin_url('admin-post.php') ); ?>" method="post">
-            <!-- Hidden field required to process post-->
-            <input type="hidden" name="action" value="bike_admin_form_submit">
-            <?php wp_nonce_field( 'bike_admin_form_nonce_action', 'bike_admin_form_nonce_field' ); ?>
-            
-            <input type=" hidden" id="bike-id" name="bike-id" value="<?php echo $bikeId ?>">
-            <input type="hidden" id="bike-image-id" name="bike-image-id" value="<?php echo $bikeImageId ?>">
-            <table class="form-table gp-table">
-                <tbody>
-                    <tr>
-                        <th scope="row">
-                            <label for="bike_name">BIKE NAME:</label>
-                        </th>
-                        <td>
-                            <input id="bike-name" name="bike-name" type="text"
-                                value="<?php echo $bikeName; ?>" size="48">
-                        </td>
-                        <th scope="row">
-                            <label for="bike-desc">DESCRIPTION:</label>
-                        </th>
-                        <td rowspan="3">
-                            <input id="bike-desc" name="bike-desc" type="textarea"
-                                value="<?php echo $bikeDescription; ?>" rows="8" cols="50">
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">
-                            <label for="bike_make">BIKE MAKE:</label>
-                        </th>
-                        <td>
-                            <input id="bike-make" name="bike-make" type="text"
-                                value="<?php echo $bikeMake; ?>" size="48">
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">
-                            <label for="bike_model">BIKE MODEL:</label>
-                        </th>
-                        <td>
-                            <input id="bike-model" name="bike-model" type="text"
-                                value="<?php echo $bikeModel; ?>" size="48">
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">
-                            <label for="serial-number">SERIAL NUMBER:</label>
-                        </th>
-                        <td>
-                            <input id="serial-number" name="serial-number" type="text"
-                                value="<?php echo $serialNumber; ?>" size="48">
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">
-                            <label for="bike_status">BIKE STATUS:</label>
-                        </th>
-                        <td>
-                            <select id="bike-status" name="bike-status" type="text" value="">
-                                <?php
-                                foreach ($aStatuses as $status) {
-                                    echo "<option name=\"$status->bike_status\"";
-                                    if ($bikeStatusId == $status->id) {
-                                        echo " selected ";
-                                    }
-                                    echo ">$status->bike_status</option>";
-                                }
-                                ?>
-                            </select>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">
-                            <label for="bike_status">IMAGE:</label>
-                        </th>
-                        <td>
-                            <div id="bike_image_container">
-                                <?php echo $imageTag; ?>
-                            </div>
-                            <button id="select_image_button" class="button button-primary">Select Image</button>
-                            <div>
-                                <a href="javascript:deleteImage();">Delete</a>
-                            </div>
-                            <input type="hidden" id="bike-image-id"
-                                name="bike-image-id" value="0">
-                        </td>
-                    </tr>
-                    <tr>
-                        <td scope="row">
-                            &nbsp;
-                        </td>
-                        <td>
-                            <?php
-                            if ($mode != 'new') {
-                                ?>
-                                <button id="update-bike" name="update" type="submit" onclick="submitForm()">Update
-                                    Bike</button>
-                            <?php
-                            }
-                            ?>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </form>
-        <table id="bike-list" class="wp-list-table widefat">
-            <thead>
-                <tr id="bike-list-header">
-                    <th scope="col" class="manage-column">Bike Name</th>
-                    <th scope="col" class="manage-column">Make</th>
-                    <th scope="col" class="manage-column">Model</th>
-                    <th scope="col" class="manage-column">Actions</th>
-                </tr>
-            </thead>
+<div class="wrap bikepress-bikes-admin">
+	<?php include plugin_dir_path( __FILE__ ) . 'bike-admin-header.php'; ?>
 
-            <?php
-            $bAlternateRow = false;
-            foreach ($aBikes as $bike) {
-                echo "<tr id=\"bike_$bike->id\">";
-                echo "<td>$bike->bike_name</td>";
-                echo "<td>$bike->bike_make</td>";
-                echo "<td>$bike->bike_model</td>";
-                //TOFO:  THE URL NEEDS TO BE A CONSTANT
-                echo "<td><a href=\"http://127.0.0.1/wp-sandbox/wp-admin/admin.php?page=bikes-admin&sbmaction=edit&bike_id=$bike->id\">EDIT</a> / <a href=\"\">DELETE</a></td>";
-                echo "</tr>";
-            }
-            ?>
-        </table>
-    </main>
-    <?php include(plugin_dir_path(__FILE__) . 'bike-admin-footer.php'); ?>
+	<h1 class="wp-heading-inline"><?php esc_html_e( 'Manage Bikes', 'bikepress' ); ?></h1>
+	<?php if ( 'list' === $action ) : ?>
+		<a href="<?php echo esc_url( $new_url ); ?>" class="page-title-action"><?php esc_html_e( 'Add New Bike', 'bikepress' ); ?></a>
+	<?php endif; ?>
+	<hr class="wp-header-end" />
+
+	<?php if ( $notice && isset( $notice_messages[ $notice ] ) ) : ?>
+		<div class="notice notice-<?php echo esc_attr( $notice_messages[ $notice ][0] ); ?> is-dismissible">
+			<p><?php echo esc_html( $notice_messages[ $notice ][1] ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( 'delete' === $action && $bike ) : ?>
+		<div class="notice notice-warning">
+			<p>
+				<?php
+				echo esc_html(
+					sprintf(
+						/* translators: %s: bike name */
+						__( 'Delete “%s”? This will also permanently delete related specs and maintenance records.', 'bikepress' ),
+						$bike->bike_name
+					)
+				);
+				?>
+			</p>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="bikepress_delete_bike" />
+				<input type="hidden" name="bike_id" value="<?php echo esc_attr( (string) $bike->id ); ?>" />
+				<?php wp_nonce_field( 'bikepress_delete_bike', 'bikepress_delete_bike_nonce' ); ?>
+				<?php submit_button( __( 'Yes, delete bike', 'bikepress' ), 'delete', 'submit', false ); ?>
+				<a class="button" href="<?php echo esc_url( $list_url ); ?>"><?php esc_html_e( 'Cancel', 'bikepress' ); ?></a>
+			</form>
+		</div>
+
+	<?php elseif ( 'new' === $action || 'edit' === $action ) : ?>
+		<h2><?php echo 'edit' === $action ? esc_html__( 'Edit Bike', 'bikepress' ) : esc_html__( 'Add New Bike', 'bikepress' ); ?></h2>
+
+		<?php if ( empty( $statuses ) ) : ?>
+			<div class="notice notice-error">
+				<p><?php esc_html_e( 'No statuses found. Activate the plugin with demo data enabled, or add statuses before creating bikes.', 'bikepress' ); ?></p>
+			</div>
+		<?php endif; ?>
+
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" id="bikepress-bike-form">
+			<input type="hidden" name="action" value="bikepress_save_bike" />
+			<input type="hidden" name="bike_id" value="<?php echo esc_attr( (string) $form_bike_id ); ?>" />
+			<?php wp_nonce_field( 'bikepress_save_bike', 'bikepress_bike_nonce' ); ?>
+
+			<table class="form-table" role="presentation">
+				<tbody>
+					<tr>
+						<th scope="row"><label for="bike_name"><?php esc_html_e( 'Bike name', 'bikepress' ); ?></label></th>
+						<td><input name="bike_name" id="bike_name" type="text" class="regular-text" required value="<?php echo esc_attr( $form_name ); ?>" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="bike_make"><?php esc_html_e( 'Make', 'bikepress' ); ?></label></th>
+						<td><input name="bike_make" id="bike_make" type="text" class="regular-text" value="<?php echo esc_attr( $form_make ); ?>" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="bike_model"><?php esc_html_e( 'Model', 'bikepress' ); ?></label></th>
+						<td><input name="bike_model" id="bike_model" type="text" class="regular-text" value="<?php echo esc_attr( $form_model ); ?>" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="serial_number"><?php esc_html_e( 'Serial number', 'bikepress' ); ?></label></th>
+						<td><input name="serial_number" id="serial_number" type="text" class="regular-text" value="<?php echo esc_attr( $form_serial ); ?>" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="bike_status_id"><?php esc_html_e( 'Status', 'bikepress' ); ?></label></th>
+						<td>
+							<select name="bike_status_id" id="bike_status_id" required>
+								<option value=""><?php esc_html_e( '— Select —', 'bikepress' ); ?></option>
+								<?php foreach ( (array) $statuses as $status_row ) : ?>
+									<option value="<?php echo esc_attr( (string) $status_row->id ); ?>" <?php selected( $form_status_id, (int) $status_row->id ); ?>>
+										<?php echo esc_html( $status_row->bike_status ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="purchase_date"><?php esc_html_e( 'Purchase date', 'bikepress' ); ?></label></th>
+						<td><input name="purchase_date" id="purchase_date" type="date" value="<?php echo esc_attr( $form_purchase_date ); ?>" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="bike_desc"><?php esc_html_e( 'Description', 'bikepress' ); ?></label></th>
+						<td><textarea name="bike_desc" id="bike_desc" class="large-text" rows="5"><?php echo esc_textarea( $form_desc ); ?></textarea></td>
+					</tr>
+					<tr>
+						<th scope="row"><?php esc_html_e( 'Image', 'bikepress' ); ?></th>
+						<td>
+							<div id="bike_image_container" style="margin-bottom:8px;">
+								<img id="bike-image" src="<?php echo esc_url( $preview_url ); ?>" alt="" style="max-width:200px;height:auto;" />
+							</div>
+							<input type="hidden" name="bike_image_id" id="bike-image-id" value="<?php echo esc_attr( (string) $form_image_id ); ?>" />
+							<button type="button" class="button" id="select_image_button"><?php esc_html_e( 'Select image', 'bikepress' ); ?></button>
+							<button type="button" class="button" id="clear_image_button"><?php esc_html_e( 'Clear image', 'bikepress' ); ?></button>
+							<p class="description" id="bikepress-default-image" data-default-src="<?php echo esc_url( $default_image ); ?>">
+								<?php esc_html_e( 'Uses the default bike image when cleared.', 'bikepress' ); ?>
+							</p>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<?php
+			submit_button(
+				'edit' === $action ? __( 'Update bike', 'bikepress' ) : __( 'Add bike', 'bikepress' )
+			);
+			?>
+			<a class="button" href="<?php echo esc_url( $list_url ); ?>"><?php esc_html_e( 'Cancel', 'bikepress' ); ?></a>
+		</form>
+
+		<?php if ( 'edit' === $action && $form_bike_id > 0 ) : ?>
+			<hr />
+			<p>
+				<strong><?php esc_html_e( 'Related records (Phase 2)', 'bikepress' ); ?></strong><br />
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=specs-admin&bike_id=' . $form_bike_id ) ); ?>">
+					<?php esc_html_e( 'Manage specs for this bike', 'bikepress' ); ?>
+				</a>
+				&nbsp;|&nbsp;
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=maint-admin&bike_id=' . $form_bike_id ) ); ?>">
+					<?php esc_html_e( 'Manage maintenance for this bike', 'bikepress' ); ?>
+				</a>
+			</p>
+		<?php endif; ?>
+
+	<?php else : ?>
+		<?php
+		$bikes = $wpdb->get_results(
+			'SELECT b.*, s.bike_status FROM ' . BIKES_TABLE . ' b
+			LEFT JOIN ' . STATUS_TABLE . ' s ON b.bike_status_id = s.id
+			ORDER BY b.bike_name ASC'
+		); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		?>
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Name', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Make', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Model', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Status', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Actions', 'bikepress' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php if ( empty( $bikes ) ) : ?>
+					<tr>
+						<td colspan="5"><?php esc_html_e( 'No bikes found.', 'bikepress' ); ?></td>
+					</tr>
+				<?php else : ?>
+					<?php foreach ( $bikes as $row ) : ?>
+						<?php
+						$edit_url   = admin_url( 'admin.php?page=bikes-admin&action=edit&bike_id=' . absint( $row->id ) );
+						$delete_url = admin_url( 'admin.php?page=bikes-admin&action=delete&bike_id=' . absint( $row->id ) );
+						?>
+						<tr>
+							<td><strong><a href="<?php echo esc_url( $edit_url ); ?>"><?php echo esc_html( $row->bike_name ); ?></a></strong></td>
+							<td><?php echo esc_html( $row->bike_make ); ?></td>
+							<td><?php echo esc_html( $row->bike_model ); ?></td>
+							<td><?php echo esc_html( $row->bike_status ? $row->bike_status : '—' ); ?></td>
+							<td>
+								<a href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Edit', 'bikepress' ); ?></a>
+								|
+								<a href="<?php echo esc_url( $delete_url ); ?>"><?php esc_html_e( 'Delete', 'bikepress' ); ?></a>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
 </div>
-<style>
-    #bike-list tr:nth-child(odd) {
-        background-color: #f6f6f6;
-    }
-
-    #bike-list #bike-list-header {
-        background-color: lightsteelblue;
-    }
-
-    #submit-bike {
-        padding 10px;
-        border-radius: 8px;
-        background-color: lightsteelblue;
-        font-size: 16px;
-        color: white;
-        border: none;
-        padding: 12px;
-    }
-
-    #bike-desc {
-        width: 300px;
-        height: 150px;
-        padding: 12px;
-    }
-</style>
-<script>
-    // When the delete image link is chosen replace the image wuith the default
-    function deleteImage() {
-        // Remove Bike Image Id
-        const bikeImageIdElement = document.getElementById('bike-image-id');
-        bikeImageIdElement.value = '';
-        // Replace Bike Image with default-bike
-        const bikeImage = document.getElementById('bike-image');
-        // TODO Better path to image
-        bikeImage.src = '../wp-content/plugins/wp-bikepress/img/default-bike.jpg';
-        return true;
-    }
-
-    function validateForm(form) {
-        const name = form.bike - name.value;
-        const desc = form.bike - name.value;
-        let errorMessage = ''
-        var isValid = true
-        //const email = form.email.value;
-        //const emailRegex = /^[\w-]+(\.[\w-]+)*@([\w-]+\.)+[a-zA-Z]{2,7}$/;
-        console.log('Bike Name: ' + name)
-        if (!name) {
-            console.log('NO NAME')
-            errorMessage += 'Bike Name is required\n'
-            isValid = false
-        }
-        if (!desc) {
-            errorMessage += 'Bike Description is required\n'
-            isValid = false
-        }
-
-        if (!isValid)
-            alert(errorMessage)
-
-        return isValid;
-    }
-
-    // Validate the form befor esubmitting
-    function submitForm() {
-        console.log('Validating form!')
-
-        const form = document.getElementById('bikepress-bike-form');
-        form.addEventListener('submit', (event) => {
-            event.preventDefault();
-            if (!validateForm(form)) {
-                console.log('NOT VALID')
-                return;
-            }
-        });
-        console.log('VALID')
-
-        form.submit();
-
-    }
-
-</script>

--- a/docs/versions/version-5.0.md
+++ b/docs/versions/version-5.0.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Major release focused on WordPress lifecycle hardening: prefixed table names, gated/simplified demo data, non-destructive deactivation, fuller uninstall, asset enqueue cleanup, and shortcode escaping—without expanding incomplete admin CRUD.
+Major release for lifecycle hardening plus the start of admin CRUD: Manage Bikes (list/add/edit/delete with cascade), while specs/maintenance/status CRUD remain phased for later.
 
 ## Changes
 
@@ -21,6 +21,15 @@ Major release focused on WordPress lifecycle hardening: prefixed table names, ga
     - Shortcode output escaped; plugin version set to 5.0.0
   - Why: Safer install/activate/deactivate/uninstall behavior and a portable demo dataset while admin CRUD is still incomplete
 
+- **bikes-crud** (`version5.0-feature-bikes-crud`): Phase 1 admin CRUD for bikes
+  - What changed:
+    - Manage Bikes list / add / edit / delete with nonce, capabilities, and sanitized fields
+    - Delete confirms first, then removes related specs and maintenance for that bike
+    - Media library image select/clear; status dropdown from statuses table
+    - Phase 2 prep links on bike edit (specs/maintenance for `bike_id`)
+    - My Bikes card hub look unchanged; manage page uses standard WP admin UI
+  - Why: Maintain the bike fleet in admin without relying only on demo seed data
+
 ### Bugfixes
 
 _(none as a separate change)_
@@ -33,3 +42,4 @@ _(none as a separate change)_
 - Prefer uninstall → install → activate for a clean schema/demo seed
 - Demo default on; disable with `define( 'BIKEPRESS_LOAD_DEMO', false );` in `wp-config.php`
 - Custom-prefix sites that still have old hardcoded `wp_*` tables should reinstall rather than expect auto-migration
+- Test bikes CRUD: My Bikes → Manage Bikes → add/edit/delete (confirm cascade)

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,38 +1,37 @@
-jQuery(document).ready(function($) {
-    var frame;
+jQuery(document).ready(function ($) {
+	var frame;
+	var $imageId = $('#bike-image-id');
+	var $image = $('#bike-image');
+	var defaultSrc = $('#bikepress-default-image').data('default-src') || '';
 
-    $('#select_image_button').on('click', function(e) {
-        e.preventDefault();
+	$('#select_image_button').on('click', function (e) {
+		e.preventDefault();
 
-        // If the media frame already exists, reopen it.
-        if (frame) {
-            frame.open();
-            return;
-        }
+		if (frame) {
+			frame.open();
+			return;
+		}
 
-        // Create a new media frame
-        frame = wp.media({
-            title: 'Select or Upload Media File',
-            button: {
-                text: 'Use this media'
-            },
-            multiple: false // Set to true for multiple file selection
-        });
+		frame = wp.media({
+			title: 'Select or Upload Bike Image',
+			button: { text: 'Use this image' },
+			multiple: false
+		});
 
-        // When an image is selected, run a callback
-        frame.on('select', function() {
-            console.log('Chose Image');
-            // Get media attachment details from the selection
-            var attachment = frame.state().get('selection').first().toJSON();
-            console.log('Image ID ' +attachment.id );
+		frame.on('select', function () {
+			var attachment = frame.state().get('selection').first().toJSON();
+			$imageId.val(attachment.id);
+			$image.attr('src', attachment.url);
+		});
 
-            // Do something with the attachment data (e.g., display a preview, save the ID)
-            $('#bike-image-id').val(attachment.id);
-            console.log('Changing IMAGE URL TO ' + attachment.url);
-            $('#bike-image').attr('src', attachment.url);
-        });
+		frame.open();
+	});
 
-        // Open the media frame
-        frame.open();
-    });
+	$('#clear_image_button').on('click', function (e) {
+		e.preventDefault();
+		$imageId.val('0');
+		if (defaultSrc) {
+			$image.attr('src', defaultSrc);
+		}
+	});
 });

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -40,7 +40,8 @@ define( 'STATUS_TABLE', bikepress_status_table() );
 
 add_action( 'admin_menu', 'bike_maintenance_setup_menu' );
 add_action( 'admin_enqueue_scripts', 'bikepress_enqueue_admin_assets' );
-add_action( 'admin_post_bike_admin_form_submit', 'handle_bike_admin_form_submission' );
+add_action( 'admin_post_bikepress_save_bike', 'bikepress_handle_save_bike' );
+add_action( 'admin_post_bikepress_delete_bike', 'bikepress_handle_delete_bike' );
 
 /**
  * Enqueue BikePress admin CSS/fonts on plugin screens; media JS on bikes-admin only.
@@ -99,10 +100,26 @@ function bike_maintenance_setup_menu() {
 }
 
 /**
- * Stub form handler (admin CRUD still incomplete).
+ * Redirect helper for Manage Bikes with a notice query arg.
+ *
+ * @param string $notice Notice slug.
+ * @param array  $extra  Extra query args.
  */
-function handle_bike_admin_form_submission() {
-	if ( ! isset( $_POST['bike_admin_form_nonce_field'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bike_admin_form_nonce_field'] ) ), 'bike_admin_form_nonce_action' ) ) {
+function bikepress_redirect_bikes_admin( $notice = '', $extra = array() ) {
+	$args = array( 'page' => 'bikes-admin' );
+	if ( $notice ) {
+		$args['bikepress_notice'] = $notice;
+	}
+	$args = array_merge( $args, $extra );
+	wp_safe_redirect( add_query_arg( $args, admin_url( 'admin.php' ) ) );
+	exit;
+}
+
+/**
+ * Save (insert/update) a bike.
+ */
+function bikepress_handle_save_bike() {
+	if ( ! isset( $_POST['bikepress_bike_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bikepress_bike_nonce'] ) ), 'bikepress_save_bike' ) ) {
 		wp_die( esc_html__( 'Security check failed', 'bikepress' ) );
 	}
 
@@ -110,15 +127,94 @@ function handle_bike_admin_form_submission() {
 		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
 	}
 
-	$bike_name = isset( $_POST['bike_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bike_name'] ) ) : '';
-	$bike_make = isset( $_POST['bike_make'] ) ? sanitize_text_field( wp_unslash( $_POST['bike_make'] ) ) : '';
+	global $wpdb;
 
-	update_option( 'bike_name', $bike_name );
-	update_option( 'bike_make', $bike_make );
+	$bike_id         = isset( $_POST['bike_id'] ) ? absint( $_POST['bike_id'] ) : 0;
+	$bike_name       = isset( $_POST['bike_name'] ) ? sanitize_text_field( wp_unslash( $_POST['bike_name'] ) ) : '';
+	$bike_make       = isset( $_POST['bike_make'] ) ? sanitize_text_field( wp_unslash( $_POST['bike_make'] ) ) : '';
+	$bike_model      = isset( $_POST['bike_model'] ) ? sanitize_text_field( wp_unslash( $_POST['bike_model'] ) ) : '';
+	$serial_number   = isset( $_POST['serial_number'] ) ? sanitize_text_field( wp_unslash( $_POST['serial_number'] ) ) : '';
+	$bike_status_id  = isset( $_POST['bike_status_id'] ) ? absint( $_POST['bike_status_id'] ) : 0;
+	$bike_desc       = isset( $_POST['bike_desc'] ) ? sanitize_textarea_field( wp_unslash( $_POST['bike_desc'] ) ) : '';
+	$bike_image_id   = isset( $_POST['bike_image_id'] ) ? absint( $_POST['bike_image_id'] ) : 0;
+	$purchase_raw    = isset( $_POST['purchase_date'] ) ? sanitize_text_field( wp_unslash( $_POST['purchase_date'] ) ) : '';
 
-	$redirect_url = admin_url( 'admin.php?page=bikes-admin&status=success' );
-	wp_redirect( esc_url_raw( $redirect_url ) );
-	exit;
+	if ( '' === $bike_name ) {
+		bikepress_redirect_bikes_admin( 'bike_name_required', array( 'action' => $bike_id ? 'edit' : 'new', 'bike_id' => $bike_id ) );
+	}
+
+	if ( $bike_status_id <= 0 ) {
+		bikepress_redirect_bikes_admin( 'bike_status_required', array( 'action' => $bike_id ? 'edit' : 'new', 'bike_id' => $bike_id ) );
+	}
+
+	$purchase_date = '0000-00-00 00:00:00';
+	if ( $purchase_raw && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $purchase_raw ) ) {
+		$purchase_date = $purchase_raw . ' 00:00:00';
+	}
+
+	$row = array(
+		'last_update'    => current_time( 'mysql' ),
+		'bike_name'      => $bike_name,
+		'bike_make'      => $bike_make,
+		'bike_model'     => $bike_model,
+		'serial_number'  => $serial_number,
+		'bike_status_id' => $bike_status_id,
+		'bike_desc'      => $bike_desc,
+		'bike_image_id'  => $bike_image_id,
+		'purchase_date'  => $purchase_date,
+	);
+
+	$formats = array( '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%d', '%s' );
+
+	if ( $bike_id > 0 ) {
+		$updated = $wpdb->update(
+			BIKES_TABLE,
+			$row,
+			array( 'id' => $bike_id ),
+			$formats,
+			array( '%d' )
+		);
+		if ( false === $updated ) {
+			bikepress_redirect_bikes_admin( 'bike_save_error', array( 'action' => 'edit', 'bike_id' => $bike_id ) );
+		}
+		bikepress_redirect_bikes_admin( 'bike_updated' );
+	}
+
+	$inserted = $wpdb->insert( BIKES_TABLE, $row, $formats );
+	if ( false === $inserted ) {
+		bikepress_redirect_bikes_admin( 'bike_save_error', array( 'action' => 'new' ) );
+	}
+	bikepress_redirect_bikes_admin( 'bike_created' );
+}
+
+/**
+ * Delete a bike and its related specs and maintenance rows.
+ */
+function bikepress_handle_delete_bike() {
+	if ( ! isset( $_POST['bikepress_delete_bike_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bikepress_delete_bike_nonce'] ) ), 'bikepress_delete_bike' ) ) {
+		wp_die( esc_html__( 'Security check failed', 'bikepress' ) );
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+	}
+
+	global $wpdb;
+
+	$bike_id = isset( $_POST['bike_id'] ) ? absint( $_POST['bike_id'] ) : 0;
+	if ( $bike_id <= 0 ) {
+		bikepress_redirect_bikes_admin( 'bike_delete_error' );
+	}
+
+	$wpdb->delete( SPECS_TABLE, array( 'bike_id' => $bike_id ), array( '%d' ) );
+	$wpdb->delete( MAINTENANCE_TABLE, array( 'bike_id' => $bike_id ), array( '%d' ) );
+	$deleted = $wpdb->delete( BIKES_TABLE, array( 'id' => $bike_id ), array( '%d' ) );
+
+	if ( false === $deleted || 0 === $deleted ) {
+		bikepress_redirect_bikes_admin( 'bike_delete_error' );
+	}
+
+	bikepress_redirect_bikes_admin( 'bike_deleted' );
 }
 
 /**
@@ -129,7 +225,7 @@ function my_bikes() {
 }
 
 /**
- * Admin: manage bikes (incomplete CRUD).
+ * Admin: manage bikes CRUD.
  */
 function bikes_admin() {
 	include plugin_dir_path( __FILE__ ) . 'admin/partials/bikes-admin-page.php';


### PR DESCRIPTION
## Summary
- Change type: Feature
- Version line: version5.0
- Manage Bikes list / add / edit / delete with nonces and sanitization
- Confirmed delete cascades to specs and maintenance for that bike
- Media library image select/clear; status dropdown
- Phase 2 prep links on bike edit (specs/maintenance for bike_id)
- My Bikes hub look unchanged

## Test plan
- [ ] Install `wp-bikepress-v5.0.zip` on sandbox WP
- [ ] My Bikes → Manage Bikes → add a bike with all fields + image
- [ ] Edit and save changes
- [ ] Delete with cancel leaves data; confirm removes bike + related rows
- [ ] Shortcode still lists bikes
- [ ] Specs/maint Phase 2 links appear on edit (filtering comes later)

## Notes
- Merging will be handled outside GitHub for now unless requested otherwise.