### PR TITLE
Add Phase 2 specs and maintenance admin CRUD

### DIFF
--- a/admin/partials/maint-admin-page.php
+++ b/admin/partials/maint-admin-page.php
@@ -1,21 +1,250 @@
 <?php
 /**
- * Specs Maintenance Page
+ * Manage Maintenance — list, add, edit, delete (Phase 2 CRUD).
+ *
+ * @package BikePress
  */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+}
+
 global $wpdb;
 
-$aMaintLogs = $wpdb->get_results("SELECT * FROM " . MAINTENANCE_TABLE);
+$action         = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : 'list';
+$maint_id       = isset( $_GET['maint_id'] ) ? absint( $_GET['maint_id'] ) : 0;
+$filter_bike_id = isset( $_GET['bike_id'] ) ? absint( $_GET['bike_id'] ) : 0;
 
+if ( ! in_array( $action, array( 'list', 'new', 'edit', 'delete' ), true ) ) {
+	$action = 'list';
+}
+
+$bikes = $wpdb->get_results( 'SELECT id, bike_name FROM ' . BIKES_TABLE . ' ORDER BY bike_name ASC' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+$list_args = array( 'page' => 'maint-admin' );
+$new_args  = array( 'page' => 'maint-admin', 'action' => 'new' );
+if ( $filter_bike_id > 0 ) {
+	$list_args['bike_id'] = $filter_bike_id;
+	$new_args['bike_id']  = $filter_bike_id;
+}
+$list_url = add_query_arg( $list_args, admin_url( 'admin.php' ) );
+$new_url  = add_query_arg( $new_args, admin_url( 'admin.php' ) );
+
+$maint = null;
+if ( 'edit' === $action || 'delete' === $action ) {
+	if ( $maint_id <= 0 ) {
+		$action = 'list';
+	} else {
+		$maint = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . MAINTENANCE_TABLE . ' WHERE id = %d', $maint_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		if ( ! $maint ) {
+			$action   = 'list';
+			$maint_id = 0;
+		}
+	}
+}
+
+$notice = isset( $_GET['bikepress_notice'] ) ? sanitize_key( wp_unslash( $_GET['bikepress_notice'] ) ) : '';
+$notice_messages = array(
+	'maint_created'       => array( 'success', __( 'Maintenance record created.', 'bikepress' ) ),
+	'maint_updated'       => array( 'success', __( 'Maintenance record updated.', 'bikepress' ) ),
+	'maint_deleted'       => array( 'success', __( 'Maintenance record deleted.', 'bikepress' ) ),
+	'maint_save_error'    => array( 'error', __( 'Could not save the maintenance record.', 'bikepress' ) ),
+	'maint_delete_error'  => array( 'error', __( 'Could not delete the maintenance record.', 'bikepress' ) ),
+	'maint_desc_required' => array( 'error', __( 'Maintenance description is required.', 'bikepress' ) ),
+	'maint_date_required' => array( 'error', __( 'Maintenance date is required.', 'bikepress' ) ),
+	'maint_bike_required' => array( 'error', __( 'Please choose a bike.', 'bikepress' ) ),
+);
+
+$form_maint_id = 0;
+$form_bike_id  = $filter_bike_id;
+$form_desc     = '';
+$form_miles    = 0;
+$form_date     = '';
+
+if ( $maint ) {
+	$form_maint_id = absint( $maint->id );
+	$form_bike_id  = absint( $maint->bike_id );
+	$form_desc     = $maint->maintenance_desc;
+	$form_miles    = absint( $maint->bike_miles );
+	if ( ! empty( $maint->maintenance_date ) && '0000-00-00 00:00:00' !== $maint->maintenance_date ) {
+		$form_date = gmdate( 'Y-m-d', strtotime( $maint->maintenance_date ) );
+	}
+}
 ?>
-<div class="main-container">
-<?php include(plugin_dir_path(__FILE__) . 'bike-admin-header.php'); ?>
-    <h1>MANAGE MAINTENANCE LOGS</h1>
-    <main class="main-content">
-        <?php
-        foreach ($aMaintLogs as $maintLog) {
-            echo "<div>$maintLog->maintenance_desc</div>";
-        }
-        ?>
-    </main>
-    <?php include(plugin_dir_path(__FILE__) . 'bike-admin-footer.php'); ?>
+<div class="wrap bikepress-maint-admin">
+	<?php include plugin_dir_path( __FILE__ ) . 'bike-admin-header.php'; ?>
+
+	<h1 class="wp-heading-inline"><?php esc_html_e( 'Manage Maintenance Records', 'bikepress' ); ?></h1>
+	<?php if ( 'list' === $action ) : ?>
+		<a href="<?php echo esc_url( $new_url ); ?>" class="page-title-action"><?php esc_html_e( 'Add New Record', 'bikepress' ); ?></a>
+	<?php endif; ?>
+	<hr class="wp-header-end" />
+
+	<?php if ( $notice && isset( $notice_messages[ $notice ] ) ) : ?>
+		<div class="notice notice-<?php echo esc_attr( $notice_messages[ $notice ][0] ); ?> is-dismissible">
+			<p><?php echo esc_html( $notice_messages[ $notice ][1] ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( 'delete' === $action && $maint ) : ?>
+		<div class="notice notice-warning">
+			<p>
+				<?php
+				echo esc_html(
+					sprintf(
+						/* translators: %s: maintenance description */
+						__( 'Delete maintenance record “%s”?', 'bikepress' ),
+						$maint->maintenance_desc
+					)
+				);
+				?>
+			</p>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="bikepress_delete_maintenance" />
+				<input type="hidden" name="maint_id" value="<?php echo esc_attr( (string) $maint->id ); ?>" />
+				<input type="hidden" name="filter_bike_id" value="<?php echo esc_attr( (string) $filter_bike_id ); ?>" />
+				<?php wp_nonce_field( 'bikepress_delete_maintenance', 'bikepress_delete_maint_nonce' ); ?>
+				<?php submit_button( __( 'Yes, delete record', 'bikepress' ), 'delete', 'submit', false ); ?>
+				<a class="button" href="<?php echo esc_url( $list_url ); ?>"><?php esc_html_e( 'Cancel', 'bikepress' ); ?></a>
+			</form>
+		</div>
+
+	<?php elseif ( 'new' === $action || 'edit' === $action ) : ?>
+		<h2><?php echo 'edit' === $action ? esc_html__( 'Edit Maintenance Record', 'bikepress' ) : esc_html__( 'Add New Maintenance Record', 'bikepress' ); ?></h2>
+
+		<?php if ( empty( $bikes ) ) : ?>
+			<div class="notice notice-error"><p><?php esc_html_e( 'No bikes found. Add a bike first.', 'bikepress' ); ?></p></div>
+		<?php endif; ?>
+
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="bikepress_save_maintenance" />
+			<input type="hidden" name="maint_id" value="<?php echo esc_attr( (string) $form_maint_id ); ?>" />
+			<input type="hidden" name="filter_bike_id" value="<?php echo esc_attr( (string) $filter_bike_id ); ?>" />
+			<?php wp_nonce_field( 'bikepress_save_maintenance', 'bikepress_maint_nonce' ); ?>
+
+			<table class="form-table" role="presentation">
+				<tbody>
+					<tr>
+						<th scope="row"><label for="bike_id"><?php esc_html_e( 'Bike', 'bikepress' ); ?></label></th>
+						<td>
+							<select name="bike_id" id="bike_id" required>
+								<option value=""><?php esc_html_e( '— Select —', 'bikepress' ); ?></option>
+								<?php foreach ( (array) $bikes as $bike_row ) : ?>
+									<option value="<?php echo esc_attr( (string) $bike_row->id ); ?>" <?php selected( $form_bike_id, (int) $bike_row->id ); ?>>
+										<?php echo esc_html( $bike_row->bike_name ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="maintenance_date"><?php esc_html_e( 'Date', 'bikepress' ); ?></label></th>
+						<td><input name="maintenance_date" id="maintenance_date" type="date" required value="<?php echo esc_attr( $form_date ); ?>" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="maintenance_desc"><?php esc_html_e( 'Description', 'bikepress' ); ?></label></th>
+						<td><input name="maintenance_desc" id="maintenance_desc" type="text" class="regular-text" required value="<?php echo esc_attr( $form_desc ); ?>" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="bike_miles"><?php esc_html_e( 'Miles', 'bikepress' ); ?></label></th>
+						<td><input name="bike_miles" id="bike_miles" type="number" min="0" step="1" class="small-text" value="<?php echo esc_attr( (string) $form_miles ); ?>" /></td>
+					</tr>
+				</tbody>
+			</table>
+
+			<?php submit_button( 'edit' === $action ? __( 'Update record', 'bikepress' ) : __( 'Add record', 'bikepress' ) ); ?>
+			<a class="button" href="<?php echo esc_url( $list_url ); ?>"><?php esc_html_e( 'Cancel', 'bikepress' ); ?></a>
+		</form>
+
+	<?php else : ?>
+		<form method="get" action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" style="margin:1em 0;">
+			<input type="hidden" name="page" value="maint-admin" />
+			<label for="filter_bike_id" class="screen-reader-text"><?php esc_html_e( 'Filter by bike', 'bikepress' ); ?></label>
+			<select name="bike_id" id="filter_bike_id">
+				<option value="0"><?php esc_html_e( 'All bikes', 'bikepress' ); ?></option>
+				<?php foreach ( (array) $bikes as $bike_row ) : ?>
+					<option value="<?php echo esc_attr( (string) $bike_row->id ); ?>" <?php selected( $filter_bike_id, (int) $bike_row->id ); ?>>
+						<?php echo esc_html( $bike_row->bike_name ); ?>
+					</option>
+				<?php endforeach; ?>
+			</select>
+			<?php submit_button( __( 'Filter', 'bikepress' ), 'secondary', '', false ); ?>
+		</form>
+
+		<?php
+		if ( $filter_bike_id > 0 ) {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT m.*, b.bike_name FROM ' . MAINTENANCE_TABLE . ' m
+					INNER JOIN ' . BIKES_TABLE . ' b ON m.bike_id = b.id
+					WHERE m.bike_id = %d
+					ORDER BY m.maintenance_date DESC',
+					$filter_bike_id
+				)
+			); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		} else {
+			$rows = $wpdb->get_results(
+				'SELECT m.*, b.bike_name FROM ' . MAINTENANCE_TABLE . ' m
+				INNER JOIN ' . BIKES_TABLE . ' b ON m.bike_id = b.id
+				ORDER BY m.maintenance_date DESC'
+			); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+		?>
+
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Bike', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Date', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Description', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Miles', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Actions', 'bikepress' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php if ( empty( $rows ) ) : ?>
+					<tr><td colspan="5"><?php esc_html_e( 'No maintenance records found.', 'bikepress' ); ?></td></tr>
+				<?php else : ?>
+					<?php foreach ( $rows as $row ) : ?>
+						<?php
+						$edit_args   = array( 'page' => 'maint-admin', 'action' => 'edit', 'maint_id' => absint( $row->id ) );
+						$delete_args = array( 'page' => 'maint-admin', 'action' => 'delete', 'maint_id' => absint( $row->id ) );
+						if ( $filter_bike_id > 0 ) {
+							$edit_args['bike_id']   = $filter_bike_id;
+							$delete_args['bike_id'] = $filter_bike_id;
+						}
+						$edit_url   = add_query_arg( $edit_args, admin_url( 'admin.php' ) );
+						$delete_url = add_query_arg( $delete_args, admin_url( 'admin.php' ) );
+						$bike_url   = add_query_arg(
+							array(
+								'page'    => 'bikes-admin',
+								'action'  => 'edit',
+								'bike_id' => absint( $row->bike_id ),
+							),
+							admin_url( 'admin.php' )
+						);
+						$date_disp  = ( ! empty( $row->maintenance_date ) && '0000-00-00 00:00:00' !== $row->maintenance_date )
+							? gmdate( 'Y-m-d', strtotime( $row->maintenance_date ) )
+							: '—';
+						?>
+						<tr>
+							<td><a href="<?php echo esc_url( $bike_url ); ?>"><?php echo esc_html( $row->bike_name ); ?></a></td>
+							<td><?php echo esc_html( $date_disp ); ?></td>
+							<td><strong><a href="<?php echo esc_url( $edit_url ); ?>"><?php echo esc_html( $row->maintenance_desc ); ?></a></strong></td>
+							<td><?php echo esc_html( (string) $row->bike_miles ); ?></td>
+							<td>
+								<a href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Edit', 'bikepress' ); ?></a>
+								|
+								<a href="<?php echo esc_url( $delete_url ); ?>"><?php esc_html_e( 'Delete', 'bikepress' ); ?></a>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
 </div>

--- a/admin/partials/specs-admin-page.php
+++ b/admin/partials/specs-admin-page.php
@@ -1,21 +1,236 @@
 <?php
 /**
- * Specs Maintenance Page
+ * Manage Specs — list, add, edit, delete (Phase 2 CRUD).
+ *
+ * @package BikePress
  */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+if ( ! current_user_can( 'manage_options' ) ) {
+	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+}
+
 global $wpdb;
 
-$aSpecs = $wpdb->get_results("SELECT * FROM " . SPECS_TABLE);
+$action         = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : 'list';
+$spec_id        = isset( $_GET['spec_id'] ) ? absint( $_GET['spec_id'] ) : 0;
+$filter_bike_id = isset( $_GET['bike_id'] ) ? absint( $_GET['bike_id'] ) : 0;
 
+if ( ! in_array( $action, array( 'list', 'new', 'edit', 'delete' ), true ) ) {
+	$action = 'list';
+}
+
+$bikes = $wpdb->get_results( 'SELECT id, bike_name FROM ' . BIKES_TABLE . ' ORDER BY bike_name ASC' ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+$list_args = array( 'page' => 'specs-admin' );
+$new_args  = array( 'page' => 'specs-admin', 'action' => 'new' );
+if ( $filter_bike_id > 0 ) {
+	$list_args['bike_id'] = $filter_bike_id;
+	$new_args['bike_id']  = $filter_bike_id;
+}
+$list_url = add_query_arg( $list_args, admin_url( 'admin.php' ) );
+$new_url  = add_query_arg( $new_args, admin_url( 'admin.php' ) );
+
+$spec = null;
+if ( 'edit' === $action || 'delete' === $action ) {
+	if ( $spec_id <= 0 ) {
+		$action = 'list';
+	} else {
+		$spec = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM ' . SPECS_TABLE . ' WHERE id = %d', $spec_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		if ( ! $spec ) {
+			$action  = 'list';
+			$spec_id = 0;
+		}
+	}
+}
+
+$notice = isset( $_GET['bikepress_notice'] ) ? sanitize_key( wp_unslash( $_GET['bikepress_notice'] ) ) : '';
+$notice_messages = array(
+	'spec_created'       => array( 'success', __( 'Spec created.', 'bikepress' ) ),
+	'spec_updated'       => array( 'success', __( 'Spec updated.', 'bikepress' ) ),
+	'spec_deleted'       => array( 'success', __( 'Spec deleted.', 'bikepress' ) ),
+	'spec_save_error'    => array( 'error', __( 'Could not save the spec.', 'bikepress' ) ),
+	'spec_delete_error'  => array( 'error', __( 'Could not delete the spec.', 'bikepress' ) ),
+	'spec_name_required' => array( 'error', __( 'Spec name is required.', 'bikepress' ) ),
+	'spec_bike_required' => array( 'error', __( 'Please choose a bike.', 'bikepress' ) ),
+);
+
+$form_spec_id   = 0;
+$form_bike_id   = $filter_bike_id;
+$form_spec_name = '';
+$form_spec_desc = '';
+
+if ( $spec ) {
+	$form_spec_id   = absint( $spec->id );
+	$form_bike_id   = absint( $spec->bike_id );
+	$form_spec_name = $spec->spec_name;
+	$form_spec_desc = $spec->spec_desc;
+}
 ?>
-<div class="main-container">
-<?php include(plugin_dir_path(__FILE__) . 'bike-admin-header.php'); ?>
-    <h1>MANAGE SPECS</h1>
-    <main class="main-content">
-        <?php
-        foreach ($aSpecs as $spec) {
-            echo "<div>$spec->spec_name</div>";
-        }
-        ?>
-    </main>
-    <?php include(plugin_dir_path(__FILE__) . 'bike-admin-footer.php'); ?>
+<div class="wrap bikepress-specs-admin">
+	<?php include plugin_dir_path( __FILE__ ) . 'bike-admin-header.php'; ?>
+
+	<h1 class="wp-heading-inline"><?php esc_html_e( 'Manage Specs', 'bikepress' ); ?></h1>
+	<?php if ( 'list' === $action ) : ?>
+		<a href="<?php echo esc_url( $new_url ); ?>" class="page-title-action"><?php esc_html_e( 'Add New Spec', 'bikepress' ); ?></a>
+	<?php endif; ?>
+	<hr class="wp-header-end" />
+
+	<?php if ( $notice && isset( $notice_messages[ $notice ] ) ) : ?>
+		<div class="notice notice-<?php echo esc_attr( $notice_messages[ $notice ][0] ); ?> is-dismissible">
+			<p><?php echo esc_html( $notice_messages[ $notice ][1] ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( 'delete' === $action && $spec ) : ?>
+		<div class="notice notice-warning">
+			<p>
+				<?php
+				echo esc_html(
+					sprintf(
+						/* translators: %s: spec name */
+						__( 'Delete spec “%s”?', 'bikepress' ),
+						$spec->spec_name
+					)
+				);
+				?>
+			</p>
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="bikepress_delete_spec" />
+				<input type="hidden" name="spec_id" value="<?php echo esc_attr( (string) $spec->id ); ?>" />
+				<input type="hidden" name="filter_bike_id" value="<?php echo esc_attr( (string) $filter_bike_id ); ?>" />
+				<?php wp_nonce_field( 'bikepress_delete_spec', 'bikepress_delete_spec_nonce' ); ?>
+				<?php submit_button( __( 'Yes, delete spec', 'bikepress' ), 'delete', 'submit', false ); ?>
+				<a class="button" href="<?php echo esc_url( $list_url ); ?>"><?php esc_html_e( 'Cancel', 'bikepress' ); ?></a>
+			</form>
+		</div>
+
+	<?php elseif ( 'new' === $action || 'edit' === $action ) : ?>
+		<h2><?php echo 'edit' === $action ? esc_html__( 'Edit Spec', 'bikepress' ) : esc_html__( 'Add New Spec', 'bikepress' ); ?></h2>
+
+		<?php if ( empty( $bikes ) ) : ?>
+			<div class="notice notice-error"><p><?php esc_html_e( 'No bikes found. Add a bike first.', 'bikepress' ); ?></p></div>
+		<?php endif; ?>
+
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="bikepress_save_spec" />
+			<input type="hidden" name="spec_id" value="<?php echo esc_attr( (string) $form_spec_id ); ?>" />
+			<input type="hidden" name="filter_bike_id" value="<?php echo esc_attr( (string) $filter_bike_id ); ?>" />
+			<?php wp_nonce_field( 'bikepress_save_spec', 'bikepress_spec_nonce' ); ?>
+
+			<table class="form-table" role="presentation">
+				<tbody>
+					<tr>
+						<th scope="row"><label for="bike_id"><?php esc_html_e( 'Bike', 'bikepress' ); ?></label></th>
+						<td>
+							<select name="bike_id" id="bike_id" required>
+								<option value=""><?php esc_html_e( '— Select —', 'bikepress' ); ?></option>
+								<?php foreach ( (array) $bikes as $bike_row ) : ?>
+									<option value="<?php echo esc_attr( (string) $bike_row->id ); ?>" <?php selected( $form_bike_id, (int) $bike_row->id ); ?>>
+										<?php echo esc_html( $bike_row->bike_name ); ?>
+									</option>
+								<?php endforeach; ?>
+							</select>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="spec_name"><?php esc_html_e( 'Spec name', 'bikepress' ); ?></label></th>
+						<td><input name="spec_name" id="spec_name" type="text" class="regular-text" required value="<?php echo esc_attr( $form_spec_name ); ?>" /></td>
+					</tr>
+					<tr>
+						<th scope="row"><label for="spec_desc"><?php esc_html_e( 'Description', 'bikepress' ); ?></label></th>
+						<td><input name="spec_desc" id="spec_desc" type="text" class="regular-text" value="<?php echo esc_attr( $form_spec_desc ); ?>" /></td>
+					</tr>
+				</tbody>
+			</table>
+
+			<?php submit_button( 'edit' === $action ? __( 'Update spec', 'bikepress' ) : __( 'Add spec', 'bikepress' ) ); ?>
+			<a class="button" href="<?php echo esc_url( $list_url ); ?>"><?php esc_html_e( 'Cancel', 'bikepress' ); ?></a>
+		</form>
+
+	<?php else : ?>
+		<form method="get" action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" style="margin:1em 0;">
+			<input type="hidden" name="page" value="specs-admin" />
+			<label for="filter_bike_id" class="screen-reader-text"><?php esc_html_e( 'Filter by bike', 'bikepress' ); ?></label>
+			<select name="bike_id" id="filter_bike_id">
+				<option value="0"><?php esc_html_e( 'All bikes', 'bikepress' ); ?></option>
+				<?php foreach ( (array) $bikes as $bike_row ) : ?>
+					<option value="<?php echo esc_attr( (string) $bike_row->id ); ?>" <?php selected( $filter_bike_id, (int) $bike_row->id ); ?>>
+						<?php echo esc_html( $bike_row->bike_name ); ?>
+					</option>
+				<?php endforeach; ?>
+			</select>
+			<?php submit_button( __( 'Filter', 'bikepress' ), 'secondary', '', false ); ?>
+		</form>
+
+		<?php
+		if ( $filter_bike_id > 0 ) {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					'SELECT s.*, b.bike_name FROM ' . SPECS_TABLE . ' s
+					INNER JOIN ' . BIKES_TABLE . ' b ON s.bike_id = b.id
+					WHERE s.bike_id = %d
+					ORDER BY s.spec_name ASC',
+					$filter_bike_id
+				)
+			); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		} else {
+			$rows = $wpdb->get_results(
+				'SELECT s.*, b.bike_name FROM ' . SPECS_TABLE . ' s
+				INNER JOIN ' . BIKES_TABLE . ' b ON s.bike_id = b.id
+				ORDER BY b.bike_name ASC, s.spec_name ASC'
+			); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+		?>
+
+		<table class="wp-list-table widefat fixed striped">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Bike', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Spec name', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Description', 'bikepress' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Actions', 'bikepress' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php if ( empty( $rows ) ) : ?>
+					<tr><td colspan="4"><?php esc_html_e( 'No specs found.', 'bikepress' ); ?></td></tr>
+				<?php else : ?>
+					<?php foreach ( $rows as $row ) : ?>
+						<?php
+						$edit_args   = array( 'page' => 'specs-admin', 'action' => 'edit', 'spec_id' => absint( $row->id ) );
+						$delete_args = array( 'page' => 'specs-admin', 'action' => 'delete', 'spec_id' => absint( $row->id ) );
+						if ( $filter_bike_id > 0 ) {
+							$edit_args['bike_id']   = $filter_bike_id;
+							$delete_args['bike_id'] = $filter_bike_id;
+						}
+						$edit_url   = add_query_arg( $edit_args, admin_url( 'admin.php' ) );
+						$delete_url = add_query_arg( $delete_args, admin_url( 'admin.php' ) );
+						$bike_url   = add_query_arg(
+							array(
+								'page'    => 'bikes-admin',
+								'action'  => 'edit',
+								'bike_id' => absint( $row->bike_id ),
+							),
+							admin_url( 'admin.php' )
+						);
+						?>
+						<tr>
+							<td><a href="<?php echo esc_url( $bike_url ); ?>"><?php echo esc_html( $row->bike_name ); ?></a></td>
+							<td><strong><a href="<?php echo esc_url( $edit_url ); ?>"><?php echo esc_html( $row->spec_name ); ?></a></strong></td>
+							<td><?php echo esc_html( $row->spec_desc ); ?></td>
+							<td>
+								<a href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Edit', 'bikepress' ); ?></a>
+								|
+								<a href="<?php echo esc_url( $delete_url ); ?>"><?php esc_html_e( 'Delete', 'bikepress' ); ?></a>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				<?php endif; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
 </div>

--- a/docs/versions/version-5.0.md
+++ b/docs/versions/version-5.0.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Major release for lifecycle hardening plus the start of admin CRUD: Manage Bikes (list/add/edit/delete with cascade), while specs/maintenance/status CRUD remain phased for later.
+Major release for lifecycle hardening plus admin CRUD Phases 1–2: Manage Bikes, Manage Specs, and Manage Maintenance. Status CRUD remains Phase 3.
 
 ## Changes
 
@@ -30,6 +30,16 @@ Major release for lifecycle hardening plus the start of admin CRUD: Manage Bikes
     - My Bikes card hub look unchanged; manage page uses standard WP admin UI
   - Why: Maintain the bike fleet in admin without relying only on demo seed data
 
+- **specs-maint-crud** (`version5.0-feature-specs-maint-crud`): Phase 2 admin CRUD for specs and maintenance
+  - What changed:
+    - Manage Specs and Manage Maintenance: list / add / edit / delete with nonces and capability checks
+    - List all rows with bike name column; bike dropdown filter; honor `?bike_id=` from bike edit links
+    - Spec fields: bike, name, description; maintenance fields: bike, date, description, miles
+    - Delete confirms a single row only
+    - Bike name in each list links to Manage Bikes edit for that bike
+    - My Bikes card hub look unchanged
+  - Why: Maintain specs and service history in admin alongside bikes
+
 ### Bugfixes
 
 _(none as a separate change)_
@@ -43,3 +53,4 @@ _(none as a separate change)_
 - Demo default on; disable with `define( 'BIKEPRESS_LOAD_DEMO', false );` in `wp-config.php`
 - Custom-prefix sites that still have old hardcoded `wp_*` tables should reinstall rather than expect auto-migration
 - Test bikes CRUD: My Bikes → Manage Bikes → add/edit/delete (confirm cascade)
+- Test specs/maint CRUD: filter by bike, add/edit/delete; use bike-edit prep links; click bike name → bike edit

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -42,6 +42,10 @@ add_action( 'admin_menu', 'bike_maintenance_setup_menu' );
 add_action( 'admin_enqueue_scripts', 'bikepress_enqueue_admin_assets' );
 add_action( 'admin_post_bikepress_save_bike', 'bikepress_handle_save_bike' );
 add_action( 'admin_post_bikepress_delete_bike', 'bikepress_handle_delete_bike' );
+add_action( 'admin_post_bikepress_save_spec', 'bikepress_handle_save_spec' );
+add_action( 'admin_post_bikepress_delete_spec', 'bikepress_handle_delete_spec' );
+add_action( 'admin_post_bikepress_save_maintenance', 'bikepress_handle_save_maintenance' );
+add_action( 'admin_post_bikepress_delete_maintenance', 'bikepress_handle_delete_maintenance' );
 
 /**
  * Enqueue BikePress admin CSS/fonts on plugin screens; media JS on bikes-admin only.
@@ -215,6 +219,212 @@ function bikepress_handle_delete_bike() {
 	}
 
 	bikepress_redirect_bikes_admin( 'bike_deleted' );
+}
+
+/**
+ * Redirect helper for a BikePress admin page.
+ *
+ * @param string $page   Admin page slug.
+ * @param string $notice Notice slug.
+ * @param array  $extra  Extra query args.
+ */
+function bikepress_redirect_admin_page( $page, $notice = '', $extra = array() ) {
+	$args = array( 'page' => $page );
+	if ( $notice ) {
+		$args['bikepress_notice'] = $notice;
+	}
+	$args = array_merge( $args, $extra );
+	wp_safe_redirect( add_query_arg( $args, admin_url( 'admin.php' ) ) );
+	exit;
+}
+
+/**
+ * Whether a bike ID exists.
+ *
+ * @param int $bike_id Bike ID.
+ * @return bool
+ */
+function bikepress_bike_exists( $bike_id ) {
+	global $wpdb;
+	$bike_id = absint( $bike_id );
+	if ( $bike_id <= 0 ) {
+		return false;
+	}
+	$found = $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM ' . BIKES_TABLE . ' WHERE id = %d', $bike_id ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	return ! empty( $found );
+}
+
+/**
+ * Save (insert/update) a spec.
+ */
+function bikepress_handle_save_spec() {
+	if ( ! isset( $_POST['bikepress_spec_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bikepress_spec_nonce'] ) ), 'bikepress_save_spec' ) ) {
+		wp_die( esc_html__( 'Security check failed', 'bikepress' ) );
+	}
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+	}
+
+	global $wpdb;
+
+	$spec_id   = isset( $_POST['spec_id'] ) ? absint( $_POST['spec_id'] ) : 0;
+	$bike_id   = isset( $_POST['bike_id'] ) ? absint( $_POST['bike_id'] ) : 0;
+	$spec_name = isset( $_POST['spec_name'] ) ? sanitize_text_field( wp_unslash( $_POST['spec_name'] ) ) : '';
+	$spec_desc = isset( $_POST['spec_desc'] ) ? sanitize_text_field( wp_unslash( $_POST['spec_desc'] ) ) : '';
+	$filter_id = isset( $_POST['filter_bike_id'] ) ? absint( $_POST['filter_bike_id'] ) : 0;
+
+	$extra = array();
+	if ( $filter_id > 0 ) {
+		$extra['bike_id'] = $filter_id;
+	}
+
+	if ( ! bikepress_bike_exists( $bike_id ) ) {
+		bikepress_redirect_admin_page( 'specs-admin', 'spec_bike_required', array_merge( $extra, array( 'action' => $spec_id ? 'edit' : 'new', 'spec_id' => $spec_id ) ) );
+	}
+	if ( '' === $spec_name ) {
+		bikepress_redirect_admin_page( 'specs-admin', 'spec_name_required', array_merge( $extra, array( 'action' => $spec_id ? 'edit' : 'new', 'spec_id' => $spec_id, 'bike_id' => $bike_id ) ) );
+	}
+
+	$row = array(
+		'last_update' => current_time( 'mysql' ),
+		'bike_id'     => $bike_id,
+		'spec_name'   => $spec_name,
+		'spec_desc'   => $spec_desc,
+	);
+	$formats = array( '%s', '%d', '%s', '%s' );
+
+	if ( $spec_id > 0 ) {
+		$updated = $wpdb->update( SPECS_TABLE, $row, array( 'id' => $spec_id ), $formats, array( '%d' ) );
+		if ( false === $updated ) {
+			bikepress_redirect_admin_page( 'specs-admin', 'spec_save_error', array_merge( $extra, array( 'action' => 'edit', 'spec_id' => $spec_id ) ) );
+		}
+		bikepress_redirect_admin_page( 'specs-admin', 'spec_updated', $extra );
+	}
+
+	$inserted = $wpdb->insert( SPECS_TABLE, $row, $formats );
+	if ( false === $inserted ) {
+		bikepress_redirect_admin_page( 'specs-admin', 'spec_save_error', array_merge( $extra, array( 'action' => 'new' ) ) );
+	}
+	bikepress_redirect_admin_page( 'specs-admin', 'spec_created', $extra );
+}
+
+/**
+ * Delete a single spec row.
+ */
+function bikepress_handle_delete_spec() {
+	if ( ! isset( $_POST['bikepress_delete_spec_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bikepress_delete_spec_nonce'] ) ), 'bikepress_delete_spec' ) ) {
+		wp_die( esc_html__( 'Security check failed', 'bikepress' ) );
+	}
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+	}
+
+	global $wpdb;
+
+	$spec_id   = isset( $_POST['spec_id'] ) ? absint( $_POST['spec_id'] ) : 0;
+	$filter_id = isset( $_POST['filter_bike_id'] ) ? absint( $_POST['filter_bike_id'] ) : 0;
+	$extra     = $filter_id > 0 ? array( 'bike_id' => $filter_id ) : array();
+
+	if ( $spec_id <= 0 ) {
+		bikepress_redirect_admin_page( 'specs-admin', 'spec_delete_error', $extra );
+	}
+
+	$deleted = $wpdb->delete( SPECS_TABLE, array( 'id' => $spec_id ), array( '%d' ) );
+	if ( false === $deleted || 0 === $deleted ) {
+		bikepress_redirect_admin_page( 'specs-admin', 'spec_delete_error', $extra );
+	}
+	bikepress_redirect_admin_page( 'specs-admin', 'spec_deleted', $extra );
+}
+
+/**
+ * Save (insert/update) a maintenance record.
+ */
+function bikepress_handle_save_maintenance() {
+	if ( ! isset( $_POST['bikepress_maint_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bikepress_maint_nonce'] ) ), 'bikepress_save_maintenance' ) ) {
+		wp_die( esc_html__( 'Security check failed', 'bikepress' ) );
+	}
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+	}
+
+	global $wpdb;
+
+	$maint_id  = isset( $_POST['maint_id'] ) ? absint( $_POST['maint_id'] ) : 0;
+	$bike_id   = isset( $_POST['bike_id'] ) ? absint( $_POST['bike_id'] ) : 0;
+	$desc      = isset( $_POST['maintenance_desc'] ) ? sanitize_text_field( wp_unslash( $_POST['maintenance_desc'] ) ) : '';
+	$miles     = isset( $_POST['bike_miles'] ) ? absint( $_POST['bike_miles'] ) : 0;
+	$date_raw  = isset( $_POST['maintenance_date'] ) ? sanitize_text_field( wp_unslash( $_POST['maintenance_date'] ) ) : '';
+	$filter_id = isset( $_POST['filter_bike_id'] ) ? absint( $_POST['filter_bike_id'] ) : 0;
+
+	$extra = array();
+	if ( $filter_id > 0 ) {
+		$extra['bike_id'] = $filter_id;
+	}
+
+	if ( ! bikepress_bike_exists( $bike_id ) ) {
+		bikepress_redirect_admin_page( 'maint-admin', 'maint_bike_required', array_merge( $extra, array( 'action' => $maint_id ? 'edit' : 'new', 'maint_id' => $maint_id ) ) );
+	}
+	if ( '' === $desc ) {
+		bikepress_redirect_admin_page( 'maint-admin', 'maint_desc_required', array_merge( $extra, array( 'action' => $maint_id ? 'edit' : 'new', 'maint_id' => $maint_id, 'bike_id' => $bike_id ) ) );
+	}
+
+	$maintenance_date = '0000-00-00 00:00:00';
+	if ( $date_raw && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date_raw ) ) {
+		$maintenance_date = $date_raw . ' 00:00:00';
+	} else {
+		bikepress_redirect_admin_page( 'maint-admin', 'maint_date_required', array_merge( $extra, array( 'action' => $maint_id ? 'edit' : 'new', 'maint_id' => $maint_id, 'bike_id' => $bike_id ) ) );
+	}
+
+	$row = array(
+		'last_update'       => current_time( 'mysql' ),
+		'bike_id'           => $bike_id,
+		'maintenance_date'  => $maintenance_date,
+		'maintenance_desc'  => $desc,
+		'bike_miles'        => $miles,
+	);
+	$formats = array( '%s', '%d', '%s', '%s', '%d' );
+
+	if ( $maint_id > 0 ) {
+		$updated = $wpdb->update( MAINTENANCE_TABLE, $row, array( 'id' => $maint_id ), $formats, array( '%d' ) );
+		if ( false === $updated ) {
+			bikepress_redirect_admin_page( 'maint-admin', 'maint_save_error', array_merge( $extra, array( 'action' => 'edit', 'maint_id' => $maint_id ) ) );
+		}
+		bikepress_redirect_admin_page( 'maint-admin', 'maint_updated', $extra );
+	}
+
+	$inserted = $wpdb->insert( MAINTENANCE_TABLE, $row, $formats );
+	if ( false === $inserted ) {
+		bikepress_redirect_admin_page( 'maint-admin', 'maint_save_error', array_merge( $extra, array( 'action' => 'new' ) ) );
+	}
+	bikepress_redirect_admin_page( 'maint-admin', 'maint_created', $extra );
+}
+
+/**
+ * Delete a single maintenance row.
+ */
+function bikepress_handle_delete_maintenance() {
+	if ( ! isset( $_POST['bikepress_delete_maint_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bikepress_delete_maint_nonce'] ) ), 'bikepress_delete_maintenance' ) ) {
+		wp_die( esc_html__( 'Security check failed', 'bikepress' ) );
+	}
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
+	}
+
+	global $wpdb;
+
+	$maint_id  = isset( $_POST['maint_id'] ) ? absint( $_POST['maint_id'] ) : 0;
+	$filter_id = isset( $_POST['filter_bike_id'] ) ? absint( $_POST['filter_bike_id'] ) : 0;
+	$extra     = $filter_id > 0 ? array( 'bike_id' => $filter_id ) : array();
+
+	if ( $maint_id <= 0 ) {
+		bikepress_redirect_admin_page( 'maint-admin', 'maint_delete_error', $extra );
+	}
+
+	$deleted = $wpdb->delete( MAINTENANCE_TABLE, array( 'id' => $maint_id ), array( '%d' ) );
+	if ( false === $deleted || 0 === $deleted ) {
+		bikepress_redirect_admin_page( 'maint-admin', 'maint_delete_error', $extra );
+	}
+	bikepress_redirect_admin_page( 'maint-admin', 'maint_deleted', $extra );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Change type: Feature
- Version line: version5.0
- Manage Specs and Manage Maintenance: list / add / edit / delete with nonces and capability checks
- Bike dropdown filter (honors `?bike_id=` from bike edit links); bike name links to bike edit
- Spec fields: bike, name, description; maintenance: bike, date, description, miles
- Single-row delete confirmation; My Bikes hub unchanged

## Test plan
- [ ] Install `wp-bikepress-v5.0.zip` on sandbox WP
- [ ] Manage Specs: filter, add, edit, delete; bike name → bike edit
- [ ] Manage Maintenance: filter, add, edit, delete; bike name → bike edit
- [ ] From bike edit, open prep links and confirm filtered lists
- [ ] Confirm My Bikes card hub look unchanged

## Notes
- Merging will be handled outside GitHub for now unless requested otherwise.