### PR TITLE
Cut plugin version 1.1.0

### DIFF
--- a/.cursor/skills/bikepress-dev/SKILL.md
+++ b/.cursor/skills/bikepress-dev/SKILL.md
@@ -200,7 +200,7 @@ Do **not** edit the deployed copy under `wp-sandbox\wp-content\plugins\...` unle
 - Workspace / git root: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress`
 - Remote: `origin` → `https://github.com/offthekitchen/wp-steves-bike-maint-plugin.git` (GitHub repo name unchanged for now)
 - Default integration branch: `main`
-- Current product version line after housekeeping: **1.0.0** on `main`; create `version1.0` (or next) only when the next feature starts.
+- Current product version line: **1.1.0** on the `version1.1` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
 - This environment may hit `fatal: detected dubious ownership`. Prefer one-shot overrides:
 
 ```bash

--- a/docs/versions/version-1.0.md
+++ b/docs/versions/version-1.0.md
@@ -1,11 +1,11 @@
 # Version 1.0
 
-**Status:** Current  
+**Status:** Superseded by 1.1.0  
 **Base:** main (after merging the former version 5.0 line)
 
 ## Summary
 
-First fully functional BikePress product release, labeled **1.0.0** for WordPress and packaging. Functionally this is the completed 5.0 line (lifecycle hardening + admin CRUD Phases 1–3), renumbered so the Plugins screen and zip reflect a clean v1 starting point.
+First fully functional BikePress product release, labeled **1.0.0** for WordPress and packaging. Functionally this is the completed 5.0 line (lifecycle hardening + admin CRUD Phases 1–3), renumbered so the Plugins screen and zip reflect a clean v1 starting point. Succeeded by **1.1.0** (import/export).
 
 ## Changes
 

--- a/docs/versions/version-1.1.md
+++ b/docs/versions/version-1.1.md
@@ -1,11 +1,11 @@
 # Version 1.1
 
-**Status:** In progress  
+**Status:** Current  
 **Base:** main (BikePress 1.0.0)
 
 ## Summary
 
-Minor release adding JSON import/export of all BikePress data from the Supporting Data hub, so data can be backed up and restored across reinstalls. Plugin display version remains **1.0.0** until this line is cut as a release.
+Minor release **1.1.0** adding JSON import/export of all BikePress data from the Supporting Data hub, so data can be backed up and restored across reinstalls.
 
 ## Changes
 
@@ -19,6 +19,10 @@ Minor release adding JSON import/export of all BikePress data from the Supportin
     - Import blocked when file `db_version` does not match the site
   - Why: Preserve fleet data across uninstall/reinstall and provide a portable backup format for future schema-aware tooling
 
+- **release-1.1.0** (`version1.1-feature-release-1.1.0`): Cut plugin version 1.1.0
+  - What changed: Plugin header and `BIKEPRESS_VERSION` set to `1.1.0`
+  - Why: Ship the 1.1 line as a named WordPress plugin release
+
 ### Bugfixes
 
 _(none as a separate change)_
@@ -27,6 +31,6 @@ _(none as a separate change)_
 
 - Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.1.zip`
 - Unpacks to folder: `wp-bikepress/`
-- Plugins screen still shows **1.0.0** until the 1.1 release is cut
+- Plugins screen should show **Version 1.1.0**
 - Test: Supporting Data → Import/Export → export, re-import, mismatch db_version blocked
 - Hub-only: Import/Export not listed in the left submenu

--- a/includes/class-bikepress.php
+++ b/includes/class-bikepress.php
@@ -70,7 +70,7 @@ class BikePress {
 		if ( defined( 'BIKEPRESS_VERSION' ) ) {
 			$this->version = BIKEPRESS_VERSION;
 		} else {
-			$this->version = '1.0.0';
+			$this->version = '1.1.0';
 		}
 		$this->plugin_name = 'bikepress';
 

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -10,7 +10,7 @@
  * Plugin Name:       BikePress
  * Plugin URI:        http://www.offthekitchen.com
  * Description:       Track bicycles, specifications, and maintenance records.
- * Version:           1.0.0
+ * Version:           1.1.0
  * Author:            Off the Kitchen
  * Author URI:        http://www.offthekitchen.com
  * License:           GPL-2.0+
@@ -25,7 +25,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'BIKEPRESS_VERSION', '1.0.0' );
+define( 'BIKEPRESS_VERSION', '1.1.0' );
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-tables.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-import-export.php';


### PR DESCRIPTION
## Summary
- Sets plugin `Version` / `BIKEPRESS_VERSION` to **1.1.0**
- Marks `version-1.1.md` as current; `version-1.0.md` superseded
- Updates skill current-version note

## Test plan
- [ ] Install `wp-bikepress-v1.1.zip` — Plugins list shows **1.1.0**
- [ ] Import/export still works

## Notes
- After this merges to `version1.1`, open/merge `version1.1` → `main` to ship.