### PR TITLE
Cut plugin version 1.2.0

### DIFF
--- a/.cursor/skills/bikepress-dev/SKILL.md
+++ b/.cursor/skills/bikepress-dev/SKILL.md
@@ -200,7 +200,7 @@ Do **not** edit the deployed copy under `wp-sandbox\wp-content\plugins\...` unle
 - Workspace / git root: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress`
 - Remote: `origin` → `https://github.com/offthekitchen/wp-steves-bike-maint-plugin.git` (GitHub repo name unchanged for now)
 - Default integration branch: `main`
-- Current product version line: **1.1.0** on the `version1.1` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
+- Current product version line: **1.2.0** on the `version1.2` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
 - This environment may hit `fatal: detected dubious ownership`. Prefer one-shot overrides:
 
 ```bash

--- a/docs/versions/version-1.1.md
+++ b/docs/versions/version-1.1.md
@@ -1,11 +1,11 @@
 # Version 1.1
 
-**Status:** Current  
+**Status:** Superseded by 1.2.0  
 **Base:** main (BikePress 1.0.0)
 
 ## Summary
 
-Minor release **1.1.0** adding JSON import/export of all BikePress data from the Supporting Data hub, so data can be backed up and restored across reinstalls.
+Minor release **1.1.0** adding JSON import/export of all BikePress data from the Supporting Data hub, so data can be backed up and restored across reinstalls. Succeeded by **1.2.0** (admin footer).
 
 ## Changes
 

--- a/docs/versions/version-1.2.md
+++ b/docs/versions/version-1.2.md
@@ -1,11 +1,11 @@
 # Version 1.2
 
-**Status:** In progress  
+**Status:** Current  
 **Base:** main (BikePress 1.1.0)
 
 ## Summary
 
-Minor release updating the BikePress admin footer to two columns with real About/Contact links, plus in-plugin Data & Privacy, Terms & Conditions, and About Me pages. Plugin display version remains **1.1.0** until this line is cut as a release.
+Minor release **1.2.0** updating the BikePress admin footer to two columns with real About/Contact links, plus in-plugin Data & Privacy, Terms & Conditions, and About Me pages.
 
 ## Changes
 
@@ -16,8 +16,12 @@ Minor release updating the BikePress admin footer to two columns with real About
     - Footer reduced to two columns: About BikePress and Contact
     - Links: Documentation and Buy Me a Coffee (new tab); Website (new tab); Email (`mailto:`); Data & Privacy, Terms & Conditions, About Me (in-plugin pages)
     - Footer shown on all BikePress admin screens
-    - About Me page includes compressed about image; hub card thumbnails recompressed for smaller install zip
+    - About Me page includes compressed about image and Buy Me a Coffee CTA; hub card thumbnails recompressed for smaller install zip
   - Why: Replace placeholder footer links with usable support/legal/contact content on every admin screen
+
+- **release-1.2.0** (`version1.2-feature-release-1.2.0`): Cut plugin version 1.2.0
+  - What changed: Plugin header and `BIKEPRESS_VERSION` set to `1.2.0`
+  - Why: Ship the 1.2 line as a named WordPress plugin release
 
 ### Bugfixes
 
@@ -27,5 +31,5 @@ _(none as a separate change)_
 
 - Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.2.zip`
 - Unpacks to folder: `wp-bikepress/`
-- Plugins screen still shows **1.1.0** until the 1.2 release is cut
+- Plugins screen should show **Version 1.2.0**
 - Test footer on hubs and CRUD pages; open Privacy / Terms / About Me; confirm external links open in a new tab where specified

--- a/includes/class-bikepress.php
+++ b/includes/class-bikepress.php
@@ -70,7 +70,7 @@ class BikePress {
 		if ( defined( 'BIKEPRESS_VERSION' ) ) {
 			$this->version = BIKEPRESS_VERSION;
 		} else {
-			$this->version = '1.1.0';
+			$this->version = '1.2.0';
 		}
 		$this->plugin_name = 'bikepress';
 

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -10,7 +10,7 @@
  * Plugin Name:       BikePress
  * Plugin URI:        http://www.offthekitchen.com
  * Description:       Track bicycles, specifications, and maintenance records.
- * Version:           1.1.0
+ * Version:           1.2.0
  * Author:            Off the Kitchen
  * Author URI:        http://www.offthekitchen.com
  * License:           GPL-2.0+
@@ -25,7 +25,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'BIKEPRESS_VERSION', '1.1.0' );
+define( 'BIKEPRESS_VERSION', '1.2.0' );
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-tables.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-import-export.php';


### PR DESCRIPTION
## Summary
- Sets plugin `Version` / `BIKEPRESS_VERSION` to **1.2.0**
- Marks `version-1.2.md` as current; `version-1.1.md` superseded
- Updates skill current-version note

## Test plan
- [ ] Install `wp-bikepress-v1.2.zip` — Plugins list shows **1.2.0**
- [ ] Footer / About / Privacy / Terms still work

## Notes
- After this merges to `version1.2`, open/merge `version1.2` → `main` to ship.