### PR TITLE
Fix admin UI formatting polish

### DIFF
--- a/.cursor/skills/bikepress-dev/SKILL.md
+++ b/.cursor/skills/bikepress-dev/SKILL.md
@@ -200,7 +200,7 @@ Do **not** edit the deployed copy under `wp-sandbox\wp-content\plugins\...` unle
 - Workspace / git root: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress`
 - Remote: `origin` → `https://github.com/offthekitchen/wp-steves-bike-maint-plugin.git` (GitHub repo name unchanged for now)
 - Default integration branch: `main`
-- Current product version line: **1.2.0** on the `version1.2` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
+- Current product version line: **1.3** (`version1.3`) in progress from `main` (1.2.0 shipped); create the next `versionX.Y` from `main` when starting a new line after release.
 - This environment may hit `fatal: detected dubious ownership`. Prefer one-shot overrides:
 
 ```bash

--- a/admin/css/bikepress-admin.css
+++ b/admin/css/bikepress-admin.css
@@ -1,365 +1,246 @@
-/****** General ***********/
-* {
-   font-family: 'Raleway', sans-serif;
-}
-
+/****** BikePress admin hubs (do not use WP's .card class) ***********/
 :root {
-   --main-bg-color: #F2F2F2;
+	--main-bg-color: #F2F2F2;
+	--bikepress-hub-gap: 24px;
 }
 
-body {
-   display: flex;
-   justify-content: center;
+.bikepress-hub {
+	width: 100%;
+	max-width: 1440px;
+	padding: 32px 16px;
+	margin: 0 auto;
+	box-sizing: border-box;
+	font-family: 'Raleway', sans-serif;
 }
 
+/* Non-hub admin pages still use .main-container */
 .main-container {
-   width: 100%;
-   padding: 32px 0;
-   max-width: 1440px;
-   margin: 0 auto;
-   box-sizing: border-box;
+	width: 100%;
+	max-width: 1440px;
+	padding: 32px 16px;
+	margin: 0 auto;
+	box-sizing: border-box;
+	font-family: 'Raleway', sans-serif;
 }
 
-.main-content {
-   display: flex;
-   flex-direction: column;
-   gap: 40px;
+.bikepress-hub .main-content {
+	display: block;
+	width: 100%;
 }
 
-
-/** CARDS */
-.bike-admin-cards {
-   display: flex;
-   flex-direction: row;
-   justify-content: space-between;
-   align-items: center;
-   flex-wrap: wrap;
+.bikepress-hub h1 {
+	margin: 0 0 16px 0;
 }
 
-.card-container {
-   flex-basis: 23%;
+/** Card row — 4 across on desktop */
+.bikepress-hub-cards {
+	display: flex !important;
+	flex-direction: row !important;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-items: stretch;
+	gap: var(--bikepress-hub-gap);
+	width: 100%;
+	box-sizing: border-box;
 }
 
-.bike-admin-cards .card {
-   background-color: white;
-   border-radius: 20px;
-   padding: 0;
-   filter: drop-shadow(0px 3px 15px rgba(0, 0, 0, 0.1));
-   display: flex;
-   flex-direction: column;
-   margin-top: 33px;
-   gap: 4px;
+.bikepress-hub-card {
+	position: relative;
+	box-sizing: border-box;
+	flex: 0 0 calc((100% - (3 * var(--bikepress-hub-gap))) / 4);
+	width: calc((100% - (3 * var(--bikepress-hub-gap))) / 4);
+	max-width: calc((100% - (3 * var(--bikepress-hub-gap))) / 4);
+	min-width: 0;
+	margin: 0;
+	padding: 0;
+	border: none;
+	border-radius: 12px;
+	overflow: hidden;
+	background-color: #fff;
+	display: flex;
+	flex-direction: column;
+	filter: drop-shadow(0px 3px 15px rgba(0, 0, 0, 0.1));
+	box-shadow: 0px 13px 10px -7px rgba(0, 0, 0, 0.1);
+	transition: all .4s cubic-bezier(0.175, 0.885, 0, 1);
 }
 
-.card img {
-   object-fit: cover;
+.bikepress-hub-card:hover {
+	box-shadow: 0px 30px 18px -8px rgba(0, 0, 0, 0.1);
+	transform: scale(1.05, 1.05);
 }
 
-/* IN case I put these back */
-.card-title {
-   position:absolute;
-   top: 24px;
-   left: 16px;
-   font-size: 32px;
-   font-weight: 700;
-   color: #FFF;
-   line-height: 1.2em;
-   margin: 0 0 8px 0;
-   text-shadow: 1px 1px 2px black, 0 0 25px blue, 0 0 5px #00008b;
-   max-width: 290px;
+.bikepress-hub .admin-icon {
+	width: 40px;
+	height: 40px;
+	margin: 8px 16px;
 }
 
-.card-subtitle {
-   position:absolute;
-   bottom: 80px;
-   right: 25px;
-   font-size: 14px;
-   font-weight: 400;
-   margin: 0;
-   background-color:aliceblue;
-   padding: 4px 8px;
-   border-radius: 16px;
-
+.bikepress-hub-card .card__img {
+	visibility: hidden;
+	background-size: cover;
+	background-position: center;
+	background-repeat: no-repeat;
+	width: 100%;
+	height: 235px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
 }
 
-.admin-icon {
-   width: 40px;
-   height: 40px;
-   margin: 8px 16px;
+.bikepress-hub-card .card__info-hover {
+	position: absolute;
+	padding: 16px;
+	width: 100%;
+	opacity: 0;
+	top: 0;
+	z-index: 3;
+	box-sizing: border-box;
 }
 
-/****** Header ***********/
-header {
-   max-width: 1040px;
-   padding: 0 50px;
-   margin-bottom: 35px;
-
+.bikepress-hub-card .card__img--hover {
+	transition: 0.2s all ease-out;
+	background-size: cover;
+	background-position: center;
+	background-repeat: no-repeat;
+	width: 100%;
+	position: absolute;
+	height: 235px;
+	border-top-left-radius: 12px;
+	border-top-right-radius: 12px;
+	top: 0;
 }
 
-h1 {
-   margin: 0 0 8px 0;
+.bikepress-hub-card .card__info {
+	z-index: 2;
+	background-color: #fff;
+	border-bottom-left-radius: 12px;
+	border-bottom-right-radius: 12px;
+	padding: 16px 24px 24px 24px;
+}
+
+.bikepress-hub-card .card__subcategory {
+	font-family: 'Raleway', sans-serif;
+	text-transform: uppercase;
+	font-size: 13px;
+	letter-spacing: 2px;
+	font-weight: 500;
+	color: #868686;
+}
+
+.bikepress-hub-card .card__title {
+	margin-top: 5px;
+	margin-bottom: 10px;
+	font-family: 'Roboto Slab', serif;
+}
+
+.bikepress-hub-card .card__desc {
+	font-size: 12px;
+	font-family: 'Raleway', sans-serif;
+	font-weight: 500;
+}
+
+.bikepress-hub-card:hover .card__img--hover {
+	height: 100%;
+	opacity: 0.3;
+}
+
+.bikepress-hub-card:hover .card__info {
+	background-color: transparent;
+	position: relative;
+}
+
+.bikepress-hub-card:hover .card__info-hover {
+	opacity: 1;
 }
 
 /****** Footer ***********/
 .admin-footer {
-   min-height: 163px;
-   height: auto;
-   background-color: var(--main-bg-color);
-   width: 100%;
-   max-width: 1440px;
-   margin: 35px auto 0 auto;
-   display: flex;
-   flex-direction: row;
-   flex-wrap: wrap;
-   font-family: Raleway, sans-serif;
-   box-sizing: border-box;
+	min-height: 163px;
+	height: auto;
+	background-color: var(--main-bg-color);
+	width: 100%;
+	max-width: 1440px;
+	margin: 35px auto 0 auto;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	font-family: Raleway, sans-serif;
+	box-sizing: border-box;
 }
 
 .footer-section {
-   display: flex;
-   flex-direction: column;
-   flex-basis: 50%;
-   padding: 20px;
-   gap: 15px;
-   box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+	flex-basis: 50%;
+	padding: 20px;
+	gap: 15px;
+	box-sizing: border-box;
 }
 
 .footer-header {
-   margin: 0;
+	margin: 0;
 }
 
 ul.footer-list {
-
-   list-style-type: none; 
-   padding: 0; 
-   margin: 0; 
+	list-style-type: none;
+	padding: 0;
+	margin: 0;
 }
 
 .footer-item {
-   margin-bottom: 15px;
+	margin-bottom: 15px;
 }
 
 .footer-item a {
-
-   text-decoration: none;
-   color: black;
+	text-decoration: none;
+	color: black;
 }
 
-ul.footer-list a:hover, ul.footer-list a:visited, ul.footer-list a:active  {
-   color: black;
+ul.footer-list a:hover,
+ul.footer-list a:visited,
+ul.footer-list a:active {
+	color: black;
 }
 
 .bikepress-prose {
-   max-width: 720px;
-   margin: 1em 0 2em;
-   line-height: 1.6;
+	max-width: 720px;
+	margin: 1em 0 2em;
+	line-height: 1.6;
 }
 
 .bikepress-prose ul {
-   margin: 0.5em 0 1em 1.5em;
-   list-style: disc;
+	margin: 0.5em 0 1em 1.5em;
+	list-style: disc;
 }
 
 .bikepress-about-image img {
-   max-width: 280px;
-   width: 100%;
-   height: auto;
-   display: block;
-   margin: 0 0 1.25em;
-   border-radius: 8px;
+	max-width: 280px;
+	width: 100%;
+	height: auto;
+	display: block;
+	margin: 0 0 1.25em;
+	border-radius: 8px;
+}
+
+@media screen and (max-width: 1024px) {
+	.bikepress-hub-card {
+		flex: 0 0 calc((100% - var(--bikepress-hub-gap)) / 2);
+		width: calc((100% - var(--bikepress-hub-gap)) / 2);
+		max-width: calc((100% - var(--bikepress-hub-gap)) / 2);
+	}
 }
 
 @media screen and (max-width: 768px) {
-   .footer-section {
-      flex-basis: 100%;
-   }
-}
+	.bikepress-hub-cards {
+		flex-direction: column !important;
+	}
 
-  /* CSS FOR ANIMATION */
-  @import url('https://fonts.googleapis.com/css?family=Roboto+Slab:100,300,400,700');
-  @import url('https://fonts.googleapis.com/css?family=Raleway:300,300i,400,400i,500,500i,600,600i,700,700i,800,800i,900,900i');
+	.bikepress-hub-card {
+		flex: 1 1 100%;
+		width: 100%;
+		max-width: 100%;
+	}
 
-/*   *{
-  box-sizing: border-box;
-  }
-
-  body, html {
-   font-family: 'Roboto Slab', serif;
-   margin: 0;
-   width: 100%;
-   height: 100%;
-   padding: 0;
-  }
-
-  body {
-   background-color: #D2DBDD;
-   display: flex;
-   display: -webkit-flex;
-   -webkit-justify-content: center;
-   -webkit-align-items: center;
-   justify-content: center;
-   align-items: center;
-  } */
-
-  .manage-bikes-card .card__img, .manage-bikes-card .card__img--hover {
-     background-image: url('../img/manage-bikes-thumbnail.jpg');
-  }
-
-  .manage-specs-card .card__img, .manage-specs-card .card__img--hover {
-   background-image: url('../img/manage-specs-thumbnail.jpg');
-   }
-
-   .manage-maint-card .card__img, .manage-maint-card .card__img--hover {
-      background-image: url('../img/manage-maint-thumbnail.jpg');
-   }
-
-   .manage-data-card .card__img, .manage-data-card .card__img--hover,
-   .manage-status-card .card__img, .manage-status-card .card__img--hover,
-   .manage-import-export-card .card__img, .manage-import-export-card .card__img--hover {
-      background-image: url('../img/manage-data-thumbnail.jpg');
-   }
-
-  .card__like {
-     width: 18px;
-  }
-
-  .card__clock {
-     width: 15px;
-  vertical-align: middle;
-     fill: #AD7D52;
-  }
-  .card__time {
-     font-size: 12px;
-     color: #AD7D52;
-     vertical-align: middle;
-     margin-left: 5px;
-  }
-
-  .card__clock-info {
-     float: right;
-  }
-
-  .card__img {
-   visibility: hidden;
-   background-size: cover;
-   background-position: center;
-   background-repeat: no-repeat;
-   width: 100%;
-   height: 235px;
-   border-top-left-radius: 12px;
-   border-top-right-radius: 12px;
-  }
-
-  .card__info-hover {
-   position: absolute;
-   padding: 16px;
-   width: 100%;
-   opacity: 0;
-   top: 0;
-  }
-
-  .card__img--hover {
-   transition: 0.2s all ease-out;
-   background-size: cover;
-   background-position: center;
-   background-repeat: no-repeat;
-   width: 100%;
-   position: absolute;
-   height: 235px;
-   border-top-left-radius: 12px;
-   border-top-right-radius: 12px;
-   top: 0;
-  }
-  .card {
-   margin-right: 25px;
-   transition: all .4s cubic-bezier(0.175, 0.885, 0, 1);
-   background-color: #fff;
-   width: 33.3%;
-   position: relative;
-   border-radius: 12px;
-   overflow: hidden;
-   box-shadow: 0px 13px 10px -7px rgba(0, 0, 0,0.1);
-   flex-basis: 23%;
-  }
-  .card:hover {
-      box-shadow: 0px 30px 18px -8px rgba(0, 0, 0,0.1);
-      transform: scale(1.10, 1.10);
-  }
-
-  .card__info {
-   z-index: 2;
-   background-color: #fff;
-   border-bottom-left-radius: 12px;
-   border-bottom-right-radius: 12px;
-   padding: 16px 24px 24px 24px;
-  }
-
-  .card__subtitle {
-   font-family: 'Raleway', sans-serif;
-   text-transform: uppercase;
-   font-size: 13px;
-   letter-spacing: 2px;
-   font-weight: 500;
-   color: #868686;
-  }
-
-  .card__title {
-     margin-top: 5px;
-     margin-bottom: 10px;
-     font-family: 'Roboto Slab', serif;
-  }
-
-  .card__desc {
-     font-size: 12px;
-     font-family: 'Raleway', sans-serif;
-     font-weight: 500;
-  }
-
-  .card__author {
-     font-weight: 600;
-     text-decoration: none;
-     color: #AD7D52;
-  }
-
-  .card:hover .card__img--hover {
-     height: 100%;
-     opacity: 0.3;
-  }
-
-  .card:hover .card__info {
-     background-color: transparent;
-     position: relative;
-  }
-
-  .card:hover .card__info-hover {
-     opacity: 1;
-  }
-
-/* TABLET STYLES */
-@media screen and (max-width: 1024px)  {
-   .main-content {
-       max-width: 1024px;
-   }
-
-   .card-container {
-      flex-basis: 50%;
-   }
-
-}
-
-/* MOBILE STYLES */
-@media screen and (max-width: 768px)  {
-   .main-container {
-       min-width: auto;
-   }
-
-   .cards {
-       flex-direction: column;
-       gap: 15px;
-   }
-
-   .card-container {
-       margin: 8px;
-   }
-   
+	.footer-section {
+		flex-basis: 100%;
+	}
 }

--- a/admin/partials/bike-admin-header.php
+++ b/admin/partials/bike-admin-header.php
@@ -1,9 +1,5 @@
 <?php
 /**
- * Bike Admin Header
+ * Bike Admin Header (shared include; intentionally empty after removing return link).
  */
 ?>
-<!-- Can links be embedded a better way -->
-  <header class="admin-header">
-    <a href="admin.php?page=my-bikes">RETURN TO MY BIKES</a>
-  </header>

--- a/admin/partials/my-bikes-page.php
+++ b/admin/partials/my-bikes-page.php
@@ -1,88 +1,85 @@
 <?php
 /**
- * Bike Admin Page
+ * My Bikes hub.
+ *
+ * @package BikePress
  */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+$img_base = plugin_dir_url( __DIR__ ) . 'img/';
 ?>
-<!-- Can links be embedded a better way -->
-<link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;700&display=swap" rel="stylesheet" />
+<div class="bikepress-hub main-container">
+	<?php include plugin_dir_path( __FILE__ ) . 'bike-admin-header.php'; ?>
+	<h1><?php esc_html_e( 'MY BIKES', 'bikepress' ); ?></h1>
+	<main class="main-content">
+		<section id="bike-admin-tools" class="bike-admin-tools">
+			<div class="bikepress-hub-cards bike-admin-cards">
 
-<body>
-  <div class="main-container">
-    
-    <?php 
-    include(plugin_dir_path(__FILE__) . 'bike-admin-header.php') 
-    ?>
-    <h1>MY BIKES</h1>
-    <main class="main-content">
-      <section id="bike-admin-tools" class="bike-admin-tools">
-        <div class="cards bike-admin-cards">
+				<article class="bikepress-hub-card manage-bikes-card">
+					<div class="card__info-hover">
+						<img src="<?php echo esc_url( $img_base . 'admin-icon-bikes.png' ); ?>" alt="<?php esc_attr_e( 'bike icon', 'bikepress' ); ?>" class="admin-icon">
+					</div>
+					<div class="card__img" style="background-image:url('<?php echo esc_url( $img_base . 'manage-bikes-thumbnail.jpg' ); ?>');"></div>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=bikes-admin' ) ); ?>" class="card_link">
+						<div class="card__img--hover" style="background-image:url('<?php echo esc_url( $img_base . 'manage-bikes-thumbnail.jpg' ); ?>');"></div>
+					</a>
+					<div class="card__info">
+						<span class="card__subcategory"><?php esc_html_e( '5 bikes', 'bikepress' ); ?></span>
+						<h3 class="card__title"><?php esc_html_e( 'Manage Bikes', 'bikepress' ); ?></h3>
+						<span class="card__desc"><?php esc_html_e( 'Add new bikes and maintain existing ones', 'bikepress' ); ?></span>
+					</div>
+				</article>
 
-          <article class="card manage-bikes-card">
-            <div class="card__info-hover">
-              <img src="<?php echo plugin_dir_url(__DIR__) . 'img/admin-icon-bikes.png'; ?>" alt="bike icon"
-                class="admin-icon">
-            </div>
-            <div class="card__img"></div>
-            <a href="admin.php?page=bikes-admin" class="card_link">
-              <div class="card__img--hover"></div>
-            </a>
-            <div class="card__info">
-              <span class="card__subcategory">5 bikes</span>
-              <h3 class="card__title">Manage Bikes</h3>
-              <span class="card__desc">Add new bikes and maintain existing ones</span>
-            </div>
-          </article>
+				<article class="bikepress-hub-card manage-specs-card">
+					<div class="card__info-hover">
+						<img src="<?php echo esc_url( $img_base . 'admin-icon-specs.png' ); ?>" alt="<?php esc_attr_e( 'specs icon', 'bikepress' ); ?>" class="admin-icon">
+					</div>
+					<div class="card__img" style="background-image:url('<?php echo esc_url( $img_base . 'manage-specs-thumbnail.jpg' ); ?>');"></div>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=specs-admin' ) ); ?>" class="card_link">
+						<div class="card__img--hover" style="background-image:url('<?php echo esc_url( $img_base . 'manage-specs-thumbnail.jpg' ); ?>');"></div>
+					</a>
+					<div class="card__info">
+						<span class="card__subcategory"><?php esc_html_e( 'Subtitle', 'bikepress' ); ?></span>
+						<h3 class="card__title"><?php esc_html_e( 'Manage Specs', 'bikepress' ); ?></h3>
+						<span class="card__desc"><?php esc_html_e( 'Maintain bike specifications', 'bikepress' ); ?></span>
+					</div>
+				</article>
 
-          <article class="card manage-specs-card">
-            <div class="card__info-hover">
-              <img src="<?php echo plugin_dir_url(__DIR__) . 'img/admin-icon-specs.png'; ?>" alt="specs icon"
-                class="admin-icon">
-            </div>
-            <div class="card__img"></div>
-            <a href="admin.php?page=specs-admin" class="card_link">
-              <div class="card__img--hover"></div>
-            </a>
-            <div class="card__info">
-              <span class="card__subcategory">Subtitle</span>
-              <h3 class="card__title">Manage Specs</h3>
-              <span class="card__desc">Maintain bike specifications</span>
-            </div>
-          </article>
+				<article class="bikepress-hub-card manage-maint-card">
+					<div class="card__info-hover">
+						<img src="<?php echo esc_url( $img_base . 'admin-icon-maint.png' ); ?>" alt="<?php esc_attr_e( 'maint icon', 'bikepress' ); ?>" class="admin-icon">
+					</div>
+					<div class="card__img" style="background-image:url('<?php echo esc_url( $img_base . 'manage-maint-thumbnail.jpg' ); ?>');"></div>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=maint-admin' ) ); ?>" class="card_link">
+						<div class="card__img--hover" style="background-image:url('<?php echo esc_url( $img_base . 'manage-maint-thumbnail.jpg' ); ?>');"></div>
+					</a>
+					<div class="card__info">
+						<span class="card__subcategory"><?php esc_html_e( 'Last Maintenance: March 1, 2025', 'bikepress' ); ?></span>
+						<h3 class="card__title"><?php esc_html_e( 'Manage Maintenance Records', 'bikepress' ); ?></h3>
+						<span class="card__desc"><?php esc_html_e( 'Maintain bike maintenance records', 'bikepress' ); ?></span>
+					</div>
+				</article>
 
-          <article class="card manage-maint-card">
-            <div class="card__info-hover">
-              <img src="<?php echo plugin_dir_url(__DIR__) . 'img/admin-icon-maint.png'; ?>" alt="maint icon"
-                class="admin-icon">
-            </div>
-            <div class="card__img"></div>
-            <a href="admin.php?page=maint-admin" class="card_link">
-              <div class="card__img--hover"></div>
-            </a>
-            <div class="card__info">
-              <span class="card__subcategory">Last Maintenance: March 1, 2025</span>
-              <h3 class="card__title">Manage Maintenance Records</h3>
-              <span class="card__desc">Maintain bike maintenance records</span>
-            </div>
-          </article>
+				<article class="bikepress-hub-card manage-data-card">
+					<div class="card__info-hover">
+						<img src="<?php echo esc_url( $img_base . 'admin-icon-data.png' ); ?>" alt="<?php esc_attr_e( 'data icon', 'bikepress' ); ?>" class="admin-icon">
+					</div>
+					<div class="card__img" style="background-image:url('<?php echo esc_url( $img_base . 'manage-data-thumbnail.jpg' ); ?>');"></div>
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=supporting-data-admin' ) ); ?>" class="card_link">
+						<div class="card__img--hover" style="background-image:url('<?php echo esc_url( $img_base . 'manage-data-thumbnail.jpg' ); ?>');"></div>
+					</a>
+					<div class="card__info">
+						<span class="card__subcategory"><?php esc_html_e( 'Subtitle', 'bikepress' ); ?></span>
+						<h3 class="card__title"><?php esc_html_e( 'Manage Supporting Data', 'bikepress' ); ?></h3>
+						<span class="card__desc"><?php esc_html_e( 'Maintain supporting bike data (e.g. statuses)', 'bikepress' ); ?></span>
+					</div>
+				</article>
 
-          <article class="card manage-data-card">
-            <div class="card__info-hover">
-              <img src="<?php echo plugin_dir_url(__DIR__) . 'img/admin-icon-data.png'; ?>" alt="data icon"
-                class="admin-icon">
-            </div>
-            <div class="card__img"></div>
-            <a href="admin.php?page=supporting-data-admin" class="card_link">
-              <div class="card__img--hover"></div>
-            </a>
-            <div class="card__info">
-              <span class="card__subcategory">Subtitle</span>
-              <h3 class="card__title">Manage Supporting Data</h3>
-              <span class="card__desc">Maintain supporting bike data (e.g. statuses)</span>
-            </div>
-          </article>
-
-      </section>
-    </main>
-    <?php include(plugin_dir_path(__FILE__) . 'bike-admin-footer.php'); ?>
-  </div>
-</body>
+			</div>
+		</section>
+	</main>
+	<?php include plugin_dir_path( __FILE__ ) . 'bike-admin-footer.php'; ?>
+</div>

--- a/admin/partials/supporting-data-admin-page.php
+++ b/admin/partials/supporting-data-admin-page.php
@@ -12,36 +12,38 @@ if ( ! defined( 'WPINC' ) ) {
 if ( ! current_user_can( 'manage_options' ) ) {
 	wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'bikepress' ) );
 }
+
+$img_base = plugin_dir_url( __DIR__ ) . 'img/';
 ?>
-<div class="main-container">
+<div class="bikepress-hub main-container">
 	<?php include plugin_dir_path( __FILE__ ) . 'bike-admin-header.php'; ?>
 	<h1><?php esc_html_e( 'MANAGE SUPPORTING DATA', 'bikepress' ); ?></h1>
 	<main class="main-content">
 		<section id="supporting-data-tools" class="bike-admin-tools">
-			<div class="cards bike-admin-cards">
+			<div class="bikepress-hub-cards bike-admin-cards">
 
-				<article class="card manage-status-card">
+				<article class="bikepress-hub-card manage-status-card">
 					<div class="card__info-hover">
-						<img src="<?php echo esc_url( plugin_dir_url( __DIR__ ) . 'img/admin-icon-status.png' ); ?>" alt="<?php esc_attr_e( 'status icon', 'bikepress' ); ?>" class="admin-icon">
+						<img src="<?php echo esc_url( $img_base . 'admin-icon-status.png' ); ?>" alt="<?php esc_attr_e( 'status icon', 'bikepress' ); ?>" class="admin-icon">
 					</div>
-					<div class="card__img"></div>
+					<div class="card__img" style="background-image:url('<?php echo esc_url( $img_base . 'manage-data-thumbnail.jpg' ); ?>');"></div>
 					<a href="<?php echo esc_url( admin_url( 'admin.php?page=status-admin' ) ); ?>" class="card_link">
-						<div class="card__img--hover"></div>
+						<div class="card__img--hover" style="background-image:url('<?php echo esc_url( $img_base . 'manage-data-thumbnail.jpg' ); ?>');"></div>
 					</a>
 					<div class="card__info">
 						<span class="card__subcategory"><?php esc_html_e( 'Statuses', 'bikepress' ); ?></span>
 						<h3 class="card__title"><?php esc_html_e( 'Manage Statuses', 'bikepress' ); ?></h3>
-						<span class="card__desc"><?php esc_html_e( 'Add and maintain bike status labels', 'bikepress' ); ?></span>
+						<span class="card__desc"><?php esc_html_e( 'Add and Maintain Bike Statuses', 'bikepress' ); ?></span>
 					</div>
 				</article>
 
-				<article class="card manage-import-export-card">
+				<article class="bikepress-hub-card manage-import-export-card">
 					<div class="card__info-hover">
-						<img src="<?php echo esc_url( plugin_dir_url( __DIR__ ) . 'img/admin-icon-import-export.png' ); ?>" alt="<?php esc_attr_e( 'import export icon', 'bikepress' ); ?>" class="admin-icon">
+						<img src="<?php echo esc_url( $img_base . 'admin-icon-import-export.png' ); ?>" alt="<?php esc_attr_e( 'import export icon', 'bikepress' ); ?>" class="admin-icon">
 					</div>
-					<div class="card__img"></div>
+					<div class="card__img" style="background-image:url('<?php echo esc_url( $img_base . 'manage-data-thumbnail.jpg' ); ?>');"></div>
 					<a href="<?php echo esc_url( admin_url( 'admin.php?page=import-export-admin' ) ); ?>" class="card_link">
-						<div class="card__img--hover"></div>
+						<div class="card__img--hover" style="background-image:url('<?php echo esc_url( $img_base . 'manage-data-thumbnail.jpg' ); ?>');"></div>
 					</a>
 					<div class="card__info">
 						<span class="card__subcategory"><?php esc_html_e( 'Backup', 'bikepress' ); ?></span>

--- a/docs/versions/version-1.2.md
+++ b/docs/versions/version-1.2.md
@@ -1,6 +1,6 @@
 # Version 1.2
 
-**Status:** Current  
+**Status:** Superseded by 1.3 (in progress)  
 **Base:** main (BikePress 1.1.0)
 
 ## Summary

--- a/docs/versions/version-1.3.md
+++ b/docs/versions/version-1.3.md
@@ -1,0 +1,37 @@
+# Version 1.3
+
+**Status:** In progress  
+**Base:** main (BikePress 1.2.0)
+
+## Summary
+
+Minor release line for admin UI formatting polish: BikePress menu branding, hub card layout, plugin site link behavior, and related copy fixes.
+
+## Changes
+
+### Features
+
+_(none)_
+
+### Bugfixes
+
+- **admin-ui-formatting** (`version1.3-bugfix-admin-ui-formatting`): Admin UI formatting polish
+  - What was wrong:
+    - Top menu still said “My Bikes” instead of BikePress
+    - Hub cards used WordPress’s `.card` class and could lose thumbnails/hover layout
+    - Supporting Data / My Bikes card rows were edge-pinned or collapsed to a narrow column
+    - Shared “RETURN TO MY BIKES” header was redundant
+    - Statuses card copy still said “labels”
+    - Plugins “Visit plugin site” pointed at the wrong URL and opened in the same tab
+  - What fixed it:
+    - Top-level menu title **BikePress** (hub still My Bikes)
+    - Hub cards renamed to `bikepress-hub-card` with centered flex layout (4 across on My Bikes desktop)
+    - Removed return link from shared admin header
+    - Statuses description: **Add and Maintain Bike Statuses**
+    - `Plugin URI` → `https://www.offthekitchen.com/wordpress-development/` with `target="_blank"`
+
+## Install / test notes
+
+- Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.3.zip`
+- Unpacks to folder: `wp-bikepress/`
+- Test: left menu BikePress; My Bikes 4 cards; Supporting Data cards with images/hover; no return header; Plugins Visit plugin site opens new tab

--- a/includes/class-bikepress-tables.php
+++ b/includes/class-bikepress-tables.php
@@ -74,5 +74,24 @@ function bikepress_is_plugin_admin_screen( $hook ) {
 		'my-bikes_page_bikepress-about',
 		'my-bikes_page_data-admin',
 	);
-	return in_array( $hook, $screens, true );
+	if ( in_array( $hook, $screens, true ) ) {
+		return true;
+	}
+
+	// Fallback: some hosts/contexts pass an unexpected $hook; match on page slug.
+	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$pages = array(
+		'my-bikes',
+		'bikes-admin',
+		'specs-admin',
+		'maint-admin',
+		'supporting-data-admin',
+		'status-admin',
+		'import-export-admin',
+		'bikepress-privacy',
+		'bikepress-terms',
+		'bikepress-about',
+		'data-admin',
+	);
+	return in_array( $page, $pages, true );
 }

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -8,7 +8,7 @@
  *
  * @wordpress-plugin
  * Plugin Name:       BikePress
- * Plugin URI:        http://www.offthekitchen.com
+ * Plugin URI:        https://www.offthekitchen.com/wordpress-development/
  * Description:       Track bicycles, specifications, and maintenance records.
  * Version:           1.2.0
  * Author:            Off the Kitchen
@@ -42,6 +42,7 @@ define( 'STATUS_TABLE', bikepress_status_table() );
 add_action( 'admin_menu', 'bike_maintenance_setup_menu' );
 add_action( 'admin_enqueue_scripts', 'bikepress_enqueue_admin_assets' );
 add_action( 'admin_head', 'bikepress_hide_hub_only_submenu_items' );
+add_filter( 'plugin_row_meta', 'bikepress_plugin_row_meta', 10, 2 );
 add_action( 'admin_post_bikepress_save_bike', 'bikepress_handle_save_bike' );
 add_action( 'admin_post_bikepress_delete_bike', 'bikepress_handle_delete_bike' );
 add_action( 'admin_post_bikepress_save_spec', 'bikepress_handle_save_spec' );
@@ -54,6 +55,27 @@ add_action( 'admin_post_bikepress_export_data', 'bikepress_handle_export_data' )
 add_action( 'admin_post_bikepress_import_data', 'bikepress_handle_import_data' );
 
 /**
+ * Open "Visit plugin site" in a new tab on the Plugins screen.
+ *
+ * @param string[] $plugin_meta Row meta links.
+ * @param string   $plugin_file Plugin basename.
+ * @return string[]
+ */
+function bikepress_plugin_row_meta( $plugin_meta, $plugin_file ) {
+	if ( plugin_basename( __FILE__ ) !== $plugin_file ) {
+		return $plugin_meta;
+	}
+
+	foreach ( $plugin_meta as $index => $meta ) {
+		if ( false !== strpos( $meta, 'wordpress-development' ) ) {
+			$plugin_meta[ $index ] = preg_replace( '/<a\s/', '<a target="_blank" rel="noopener noreferrer" ', $meta, 1 );
+		}
+	}
+
+	return $plugin_meta;
+}
+
+/**
  * Enqueue BikePress admin CSS/fonts on plugin screens; media JS on bikes-admin only.
  *
  * @param string $hook Current admin page hook.
@@ -63,15 +85,16 @@ function bikepress_enqueue_admin_assets( $hook ) {
 		return;
 	}
 
+	$admin_css = plugin_dir_path( __FILE__ ) . 'admin/css/bikepress-admin.css';
 	wp_enqueue_style(
 		'bikepress-admin',
 		plugins_url( 'admin/css/bikepress-admin.css', __FILE__ ),
 		array(),
-		BIKEPRESS_VERSION
+		file_exists( $admin_css ) ? (string) filemtime( $admin_css ) : BIKEPRESS_VERSION
 	);
 	wp_enqueue_style(
 		'bikepress-google-fonts',
-		'https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;700&display=swap',
+		'https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;700&family=Roboto+Slab:wght@400;700&display=swap',
 		array(),
 		null
 	);
@@ -103,13 +126,15 @@ function bike_maintenance_setup_menu() {
 
 	add_menu_page(
 		__( 'My Bikes', 'bikepress' ),
-		__( 'My Bikes', 'bikepress' ),
+		__( 'BikePress', 'bikepress' ),
 		'manage_options',
 		'my-bikes',
 		'my_bikes',
 		$bikes_icon
 	);
 
+	// Rename the auto-created first submenu so it stays "My Bikes" under a BikePress parent.
+	add_submenu_page( 'my-bikes', __( 'My Bikes', 'bikepress' ), __( 'My Bikes', 'bikepress' ), 'manage_options', 'my-bikes', 'my_bikes' );
 	add_submenu_page( 'my-bikes', __( 'Manage Bikes', 'bikepress' ), __( 'Manage Bikes', 'bikepress' ), 'manage_options', 'bikes-admin', 'bikes_admin' );
 	add_submenu_page( 'my-bikes', __( 'Manage Specs', 'bikepress' ), __( 'Manage Specs', 'bikepress' ), 'manage_options', 'specs-admin', 'specs_admin' );
 	add_submenu_page( 'my-bikes', __( 'Manage Maintenance Records', 'bikepress' ), __( 'Manage Maintenance Records', 'bikepress' ), 'manage_options', 'maint-admin', 'maint_admin' );


### PR DESCRIPTION
## Summary
- Change type: Bugfix
- Version line: version1.3
- Renames top menu to **BikePress** (My Bikes hub unchanged)
- Fixes hub cards (no WP `.card` clash): images, hover, centered layout, 4-across on My Bikes
- Removes RETURN TO MY BIKES header; Statuses copy; Visit plugin site URL + new tab

## Test plan
- [ ] Left menu shows BikePress → My Bikes hub
- [ ] My Bikes: 4 cards across on desktop with thumbnails/hover
- [ ] Supporting Data: cards side-by-side with thumbnails/hover; full-width footer
- [ ] No RETURN TO MY BIKES on admin pages
- [ ] Statuses card: Add and Maintain Bike Statuses
- [ ] Plugins: Visit plugin site → offthekitchen wordpress-development (new tab)
- [ ] Installed and smoked-tested via `wp-bikepress-v1.3.zip`

## Notes
- Merging will be handled outside GitHub for now unless requested otherwise.