### PR TITLE
Cut plugin version 1.3.0

### DIFF
--- a/.cursor/skills/bikepress-dev/SKILL.md
+++ b/.cursor/skills/bikepress-dev/SKILL.md
@@ -200,7 +200,7 @@ Do **not** edit the deployed copy under `wp-sandbox\wp-content\plugins\...` unle
 - Workspace / git root: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress`
 - Remote: `origin` → `https://github.com/offthekitchen/wp-steves-bike-maint-plugin.git` (GitHub repo name unchanged for now)
 - Default integration branch: `main`
-- Current product version line: **1.3** (`version1.3`) in progress from `main` (1.2.0 shipped); create the next `versionX.Y` from `main` when starting a new line after release.
+- Current product version line: **1.3.0** on the `version1.3` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
 - This environment may hit `fatal: detected dubious ownership`. Prefer one-shot overrides:
 
 ```bash

--- a/docs/versions/version-1.2.md
+++ b/docs/versions/version-1.2.md
@@ -1,6 +1,6 @@
 # Version 1.2
 
-**Status:** Superseded by 1.3 (in progress)  
+**Status:** Superseded by 1.3.0  
 **Base:** main (BikePress 1.1.0)
 
 ## Summary

--- a/docs/versions/version-1.3.md
+++ b/docs/versions/version-1.3.md
@@ -1,17 +1,19 @@
 # Version 1.3
 
-**Status:** In progress  
+**Status:** Current  
 **Base:** main (BikePress 1.2.0)
 
 ## Summary
 
-Minor release line for admin UI formatting polish: BikePress menu branding, hub card layout and thumbnails, plugin site link behavior, and related copy fixes.
+Minor release **1.3.0** for admin UI formatting polish: BikePress menu branding, hub card layout and thumbnails, plugin site link behavior, and related copy fixes.
 
 ## Changes
 
 ### Features
 
-_(none)_
+- **release-1.3.0** (`version1.3-feature-release-1.3.0`): Cut plugin version 1.3.0
+  - What changed: Plugin header and `BIKEPRESS_VERSION` set to `1.3.0`
+  - Why: Ship the 1.3 line as a named WordPress plugin release
 
 ### Bugfixes
 
@@ -42,5 +44,6 @@ _(none)_
 
 - Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.3.zip`
 - Unpacks to folder: `wp-bikepress/`
+- Plugins screen should show **Version 1.3.0**
 - Test: left menu BikePress; My Bikes 4 cards; Supporting Data cards with images/hover; no return header; Plugins Visit plugin site opens new tab
 - Also test: My Bikes maint/data thumbs swapped; Supporting Data Statuses + Import/Export use new photos

--- a/includes/class-bikepress.php
+++ b/includes/class-bikepress.php
@@ -70,7 +70,7 @@ class BikePress {
 		if ( defined( 'BIKEPRESS_VERSION' ) ) {
 			$this->version = BIKEPRESS_VERSION;
 		} else {
-			$this->version = '1.2.0';
+			$this->version = '1.3.0';
 		}
 		$this->plugin_name = 'bikepress';
 

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -10,7 +10,7 @@
  * Plugin Name:       BikePress
  * Plugin URI:        https://www.offthekitchen.com/wordpress-development/
  * Description:       Track bicycles, specifications, and maintenance records.
- * Version:           1.2.0
+ * Version:           1.3.0
  * Author:            Off the Kitchen
  * Author URI:        http://www.offthekitchen.com
  * License:           GPL-2.0+
@@ -25,7 +25,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'BIKEPRESS_VERSION', '1.2.0' );
+define( 'BIKEPRESS_VERSION', '1.3.0' );
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-tables.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-import-export.php';


### PR DESCRIPTION
## Summary
- Sets plugin `Version` / `BIKEPRESS_VERSION` to **1.3.0**
- Marks `version-1.3.md` as current; `version-1.2.md` superseded
- Updates skill current-version note

## Test plan
- [ ] Install `wp-bikepress-v1.3.zip` — Plugins list shows **1.3.0**
- [ ] Menu / hubs / Visit plugin site still work as in 1.3 bugfixes

## Notes
- After this merges to `version1.3`, open/merge `version1.3` → `main` to ship.