### PR TITLE
Fix Manage Bikes Select image media library

### DIFF
--- a/.cursor/skills/bikepress-dev/SKILL.md
+++ b/.cursor/skills/bikepress-dev/SKILL.md
@@ -200,7 +200,7 @@ Do **not** edit the deployed copy under `wp-sandbox\wp-content\plugins\...` unle
 - Workspace / git root: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress`
 - Remote: `origin` → `https://github.com/offthekitchen/wp-steves-bike-maint-plugin.git` (GitHub repo name unchanged for now)
 - Default integration branch: `main`
-- Current product version line: **1.3.0** on the `version1.3` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
+- Current product version line: **1.4** (`version1.4`) in progress from `main` (1.3.0 shipped); create the next `versionX.Y` from `main` when starting a new line after release.
 - This environment may hit `fatal: detected dubious ownership`. Prefer one-shot overrides:
 
 ```bash

--- a/docs/versions/version-1.3.md
+++ b/docs/versions/version-1.3.md
@@ -1,6 +1,6 @@
 # Version 1.3
 
-**Status:** Current  
+**Status:** Superseded by 1.4 (in progress)  
 **Base:** main (BikePress 1.2.0)
 
 ## Summary

--- a/docs/versions/version-1.4.md
+++ b/docs/versions/version-1.4.md
@@ -1,0 +1,26 @@
+# Version 1.4
+
+**Status:** In progress  
+**Base:** main (BikePress 1.3.0)
+
+## Summary
+
+Minor release line for admin bugfixes after 1.3.0, starting with restoring the Manage Bikes media library image picker.
+
+## Changes
+
+### Features
+
+_(none)_
+
+### Bugfixes
+
+- **select-image-media** (`version1.4-bugfix-select-image-media`): Restore Manage Bikes Select image media library
+  - What was wrong: Select image no longer opened the WordPress media library
+  - What fixed it: Enqueue `wp_enqueue_media()` and `js/admin.js` on Manage Bikes via hook or `page=bikes-admin`, with `media-editor` / `media-views` script dependencies
+
+## Install / test notes
+
+- Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.4.zip`
+- Unpacks to folder: `wp-bikepress/`
+- Test: Manage Bikes → Select image opens media library; choose image updates preview; Clear image resets to default

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,6 +7,10 @@ jQuery(document).ready(function ($) {
 	$('#select_image_button').on('click', function (e) {
 		e.preventDefault();
 
+		if ( typeof wp === 'undefined' || ! wp.media ) {
+			return;
+		}
+
 		if (frame) {
 			frame.open();
 			return;

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -99,16 +99,31 @@ function bikepress_enqueue_admin_assets( $hook ) {
 		null
 	);
 
-	if ( 'my-bikes_page_bikes-admin' === $hook ) {
+	if ( bikepress_is_bikes_admin_screen( $hook ) ) {
 		wp_enqueue_media();
+		$admin_js = plugin_dir_path( __FILE__ ) . 'js/admin.js';
 		wp_enqueue_script(
 			'bikepress-admin-script',
-			plugins_url( '/js/admin.js', __FILE__ ),
-			array( 'jquery' ),
-			BIKEPRESS_VERSION,
+			plugins_url( 'js/admin.js', __FILE__ ),
+			array( 'jquery', 'media-editor', 'media-views' ),
+			file_exists( $admin_js ) ? (string) filemtime( $admin_js ) : BIKEPRESS_VERSION,
 			true
 		);
 	}
+}
+
+/**
+ * Whether the current admin request is the Manage Bikes screen.
+ *
+ * @param string $hook Current admin hook suffix.
+ * @return bool
+ */
+function bikepress_is_bikes_admin_screen( $hook ) {
+	if ( 'my-bikes_page_bikes-admin' === $hook ) {
+		return true;
+	}
+	$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	return 'bikes-admin' === $page;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Change type: Bugfix
- Version line: version1.4
- Restores WordPress media library for Manage Bikes Select image
- Enqueues media + admin.js on hook or `page=bikes-admin`, with media script dependencies

## Test plan
- [ ] Manage Bikes → Select image opens media library
- [ ] Choosing an image updates preview; Clear image resets default
- [ ] Installed and smoked-tested via `wp-bikepress-v1.4.zip`

## Notes
- Merging will be handled outside GitHub for now unless requested otherwise.