### PR TITLE
Seed core statuses as plugin data

### DIFF
--- a/admin/partials/my-bikes-page.php
+++ b/admin/partials/my-bikes-page.php
@@ -14,7 +14,7 @@ $notice   = isset( $_GET['bikepress_notice'] ) ? sanitize_key( wp_unslash( $_GET
 
 $notice_messages = array(
 	'demo_ok'     => array( 'success', __( 'Demo data imported.', 'bikepress' ) ),
-	'demo_exists' => array( 'warning', __( 'Demo data was not imported because bikes or statuses already exist.', 'bikepress' ) ),
+	'demo_exists' => array( 'warning', __( 'Demo data was not imported because bikes already exist.', 'bikepress' ) ),
 );
 ?>
 <div class="bikepress-hub main-container">

--- a/admin/partials/status-admin-page.php
+++ b/admin/partials/status-admin-page.php
@@ -43,11 +43,12 @@ $notice = isset( $_GET['bikepress_notice'] ) ? sanitize_key( wp_unslash( $_GET['
 $notice_messages = array(
 	'status_created'           => array( 'success', __( 'Status created.', 'bikepress' ) ),
 	'status_updated'           => array( 'success', __( 'Status updated.', 'bikepress' ) ),
-	'status_deleted'           => array( 'success', __( 'Status deleted. Bikes using it were reassigned to Unknown.', 'bikepress' ) ),
-	'status_save_error'        => array( 'error', __( 'Could not save the status.', 'bikepress' ) ),
-	'status_delete_error'      => array( 'error', __( 'Could not delete the status.', 'bikepress' ) ),
-	'status_name_required'     => array( 'error', __( 'Status name is required.', 'bikepress' ) ),
-	'status_unknown_protected' => array( 'error', __( 'The Unknown status cannot be deleted.', 'bikepress' ) ),
+	'status_deleted'             => array( 'success', __( 'Status deleted.', 'bikepress' ) ),
+	'status_deleted_reassigned'  => array( 'success', __( 'Status deleted. Bikes using it were reassigned to Unknown.', 'bikepress' ) ),
+	'status_save_error'          => array( 'error', __( 'Could not save the status.', 'bikepress' ) ),
+	'status_delete_error'        => array( 'error', __( 'Could not delete the status.', 'bikepress' ) ),
+	'status_name_required'       => array( 'error', __( 'Status name is required.', 'bikepress' ) ),
+	'status_unknown_protected'   => array( 'error', __( 'The Unknown status cannot be deleted.', 'bikepress' ) ),
 );
 
 $form_status_id = 0;
@@ -83,16 +84,40 @@ $is_unknown = $status ? ( 'Unknown' === $status->bike_status ) : false;
 				<a class="button" href="<?php echo esc_url( $list_url ); ?>"><?php esc_html_e( 'Back to list', 'bikepress' ); ?></a>
 			</div>
 		<?php else : ?>
+			<?php
+			$bike_count_for_status = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT COUNT(*) FROM ' . BIKES_TABLE . ' WHERE bike_status_id = %d',
+					absint( $status->id )
+				)
+			); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			?>
 			<div class="notice notice-warning">
 				<p>
 					<?php
-					echo esc_html(
-						sprintf(
-							/* translators: %s: status name */
-							__( 'Delete status “%s”? Bikes using this status will be reassigned to Unknown.', 'bikepress' ),
-							$status->bike_status
-						)
-					);
+					if ( $bike_count_for_status > 0 ) {
+						echo esc_html(
+							sprintf(
+								/* translators: 1: status name, 2: bike count */
+								_n(
+									'Delete status “%1$s”? %2$d bike using this status will be reassigned to Unknown.',
+									'Delete status “%1$s”? %2$d bikes using this status will be reassigned to Unknown.',
+									$bike_count_for_status,
+									'bikepress'
+								),
+								$status->bike_status,
+								$bike_count_for_status
+							)
+						);
+					} else {
+						echo esc_html(
+							sprintf(
+								/* translators: %s: status name */
+								__( 'Delete status “%s”? No bikes currently use this status.', 'bikepress' ),
+								$status->bike_status
+							)
+						);
+					}
 					?>
 				</p>
 				<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">

--- a/admin/partials/supporting-data-admin-page.php
+++ b/admin/partials/supporting-data-admin-page.php
@@ -18,7 +18,7 @@ $notice   = isset( $_GET['bikepress_notice'] ) ? sanitize_key( wp_unslash( $_GET
 
 $notice_messages = array(
 	'demo_ok'     => array( 'success', __( 'Demo data imported.', 'bikepress' ) ),
-	'demo_exists' => array( 'warning', __( 'Demo data was not imported because bikes or statuses already exist.', 'bikepress' ) ),
+	'demo_exists' => array( 'warning', __( 'Demo data was not imported because bikes already exist.', 'bikepress' ) ),
 );
 
 $demo_import_url = wp_nonce_url(
@@ -87,7 +87,7 @@ $demo_import_url = wp_nonce_url(
 					<div class="card__info">
 						<span class="card__subcategory"><?php esc_html_e( 'Sample', 'bikepress' ); ?></span>
 						<h3 class="card__title"><?php esc_html_e( 'Import Demo Data', 'bikepress' ); ?></h3>
-						<span class="card__desc"><?php esc_html_e( 'Load sample bikes, statuses, specs, and maintenance records', 'bikepress' ); ?></span>
+						<span class="card__desc"><?php esc_html_e( 'Load sample bikes, specs, and maintenance records', 'bikepress' ); ?></span>
 					</div>
 				</article>
 

--- a/docs/versions/version-1.4.md
+++ b/docs/versions/version-1.4.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Minor release line after 1.3.0: Manage Bikes media picker fix, plus optional demo data (off by default) with Supporting Data card, first-run notice, and shortcode empty state.
+Minor release line after 1.3.0: Manage Bikes media picker fix; optional demo data (bikes/specs/maint); core statuses seeded as plugin data on activate.
 
 ## Changes
 
@@ -15,7 +15,7 @@ Minor release line after 1.3.0: Manage Bikes media picker fix, plus optional dem
   - What changed:
     - Activation no longer loads demo data by default (`BIKEPRESS_LOAD_DEMO` must be true to seed on activate)
     - First-run admin notice on BikePress screens: Import demo data / No thanks
-    - Supporting Data hub card **Import Demo Data** (shared import action; blocked if bikes/statuses already exist)
+    - Supporting Data hub card **Import Demo Data** (shared import action; blocked if bikes already exist)
     - `[bikepress-bike-list]` empty state encourages adding bikes or importing demo data
   - Why: Let real installs start clean while still offering sample data on demand
 
@@ -25,9 +25,16 @@ Minor release line after 1.3.0: Manage Bikes media picker fix, plus optional dem
   - What was wrong: Select image no longer opened the WordPress media library
   - What fixed it: Enqueue `wp_enqueue_media()` and `js/admin.js` on Manage Bikes via hook or `page=bikes-admin`, with `media-editor` / `media-views` script dependencies
 
+- **plugin-data-statuses** (`version1.4-bugfix-plugin-data-statuses`): Core statuses as plugin data
+  - What was wrong: Statuses were tied to demo seed; delete always created Unknown; demo import recreated core statuses
+  - What fixed it:
+    - `BikePress_Plugin_Data::ensure_core_statuses()` seeds Active / Retired / Building on activate (insert-if-missing)
+    - Demo data is bikes/specs/maintenance only; missing status names resolve to Unknown
+    - Status delete creates Unknown only when bikes use that status
+
 ## Install / test notes
 
 - Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.4.zip`
 - Unpacks to folder: `wp-bikepress/`
-- Prefer uninstall → install → activate to verify empty start + first-run notice
-- Test: Select image media picker; demo notice/card; shortcode empty message; import blocked when data exists
+- Prefer uninstall → install → activate: 3 core statuses, no bikes; first-run notice
+- Test: delete unused status (no Unknown); demo import with deleted Active → bikes get Unknown; Select image; shortcode empty message

--- a/includes/class-bikepress-activator.php
+++ b/includes/class-bikepress-activator.php
@@ -10,7 +10,7 @@
  */
 
 /**
- * Defines activation behavior: schema create/upgrade and optional demo data.
+ * Defines activation behavior: schema create/upgrade, plugin data, and optional demo data.
  *
  * @since      1.0.0
  * @package    BikePress
@@ -20,7 +20,7 @@
 class BikePress_Activator {
 
 	/**
-	 * Create or upgrade tables; optionally load demo data.
+	 * Create or upgrade tables; seed plugin data; optionally load demo data.
 	 *
 	 * @since 1.0.0
 	 */
@@ -81,6 +81,9 @@ class BikePress_Activator {
 			PRIMARY KEY  (id)
 		) $charset_collate;";
 		dbDelta( $sql );
+
+		require_once plugin_dir_path( __FILE__ ) . 'class-bikepress-plugin-data.php';
+		BikePress_Plugin_Data::ensure_core_statuses();
 
 		if ( bikepress_should_load_demo() ) {
 			require_once plugin_dir_path( __FILE__ ) . 'test-data.php';

--- a/includes/class-bikepress-plugin-data.php
+++ b/includes/class-bikepress-plugin-data.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Built-in plugin data for BikePress (non-demo reference rows).
+ *
+ * @package BikePress
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Ensures required plugin data exists after schema create/upgrade.
+ */
+class BikePress_Plugin_Data {
+
+	/**
+	 * Core status labels seeded on activation (insert-if-missing).
+	 *
+	 * @return string[]
+	 */
+	public static function core_status_names() {
+		return array( 'Active', 'Retired', 'Building' );
+	}
+
+	/**
+	 * Ensure each core status exists; return map of name => id.
+	 *
+	 * @return array<string,int>
+	 */
+	public static function ensure_core_statuses() {
+		global $wpdb;
+
+		$status_table = bikepress_status_table();
+		$now          = current_time( 'mysql' );
+		$ids          = array();
+
+		foreach ( self::core_status_names() as $name ) {
+			$existing_id = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT id FROM {$status_table} WHERE bike_status = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					$name
+				)
+			);
+
+			if ( $existing_id > 0 ) {
+				$ids[ $name ] = $existing_id;
+				continue;
+			}
+
+			$wpdb->insert(
+				$status_table,
+				array(
+					'last_update' => $now,
+					'bike_status' => $name,
+				)
+			);
+			$ids[ $name ] = (int) $wpdb->insert_id;
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Resolve a status ID by exact name, or Unknown if that status is missing.
+	 *
+	 * Used by demo import so missing labels (e.g. deleted Active) do not recreate core statuses.
+	 *
+	 * @param string $name Status label.
+	 * @return int
+	 */
+	public static function resolve_status_id_or_unknown( $name ) {
+		global $wpdb;
+
+		$name = (string) $name;
+		if ( '' === $name ) {
+			return function_exists( 'bikepress_get_or_create_unknown_status_id' )
+				? bikepress_get_or_create_unknown_status_id()
+				: 0;
+		}
+
+		$status_table = bikepress_status_table();
+		$existing_id  = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT id FROM {$status_table} WHERE bike_status = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$name
+			)
+		);
+
+		if ( $existing_id > 0 ) {
+			return $existing_id;
+		}
+
+		return function_exists( 'bikepress_get_or_create_unknown_status_id' )
+			? bikepress_get_or_create_unknown_status_id()
+			: 0;
+	}
+}

--- a/includes/class-bikepress-tables.php
+++ b/includes/class-bikepress-tables.php
@@ -55,22 +55,20 @@ function bikepress_should_load_demo() {
 }
 
 /**
- * Whether bikes or statuses already exist (blocks demo re-import).
+ * Whether demo bikes already exist (blocks demo re-import).
+ * Core plugin statuses do not count as demo data.
  *
  * @return bool
  */
 function bikepress_has_existing_data() {
 	global $wpdb;
 
-	$bikes_table  = bikepress_bikes_table();
-	$status_table = bikepress_status_table();
+	$bikes_table = bikepress_bikes_table();
 
 	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- table names are prefixed identifiers.
 	$bike_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$bikes_table}" );
-	// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-	$status_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$status_table}" );
 
-	return ( $bike_count > 0 || $status_count > 0 );
+	return $bike_count > 0;
 }
 
 /**

--- a/includes/test-data.php
+++ b/includes/test-data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Demo / test data for BikePress activation.
+ * Demo / test data for BikePress (optional sample bikes, specs, maintenance).
  *
  * @link       http://www.offthekitchen.com
  * @since      1.0.0
@@ -12,66 +12,46 @@
 /**
  * Inserts a small demo dataset when enabled.
  *
+ * Core statuses come from BikePress_Plugin_Data, not demo data.
+ *
  * @since 1.0.0
  * @package BikePress
  */
 class Test_Data {
 
 	/**
-	 * Insert simplified demo statuses, bikes, maintenance, and specs.
+	 * Insert simplified demo bikes, maintenance, and specs.
 	 *
 	 * @since 1.0.0
 	 */
 	public static function insert_test_data() {
 		global $wpdb;
 
-		$bikes_table        = bikepress_bikes_table();
-		$maintenance_table  = bikepress_maintenance_table();
-		$specs_table        = bikepress_specs_table();
-		$status_table       = bikepress_status_table();
-		$now                = current_time( 'mysql' );
+		$bikes_table       = bikepress_bikes_table();
+		$maintenance_table = bikepress_maintenance_table();
+		$specs_table       = bikepress_specs_table();
+		$now               = current_time( 'mysql' );
 
-		// Statuses first so bikes can reference real IDs.
-		$wpdb->insert(
-			$status_table,
-			array(
-				'last_update' => $now,
-				'bike_status' => 'Active',
-			)
-		);
-		$status_active = (int) $wpdb->insert_id;
+		require_once plugin_dir_path( __FILE__ ) . 'class-bikepress-plugin-data.php';
 
-		$wpdb->insert(
-			$status_table,
-			array(
-				'last_update' => $now,
-				'bike_status' => 'Retired',
-			)
-		);
-		$status_retired = (int) $wpdb->insert_id;
-
-		$wpdb->insert(
-			$status_table,
-			array(
-				'last_update' => $now,
-				'bike_status' => 'Building',
-			)
-		);
-		$status_building = (int) $wpdb->insert_id;
+		// Use existing statuses only; missing names fall back to Unknown (do not re-seed core statuses).
+		$status_active   = BikePress_Plugin_Data::resolve_status_id_or_unknown( 'Active' );
+		$status_retired  = BikePress_Plugin_Data::resolve_status_id_or_unknown( 'Retired' );
+		$status_building = BikePress_Plugin_Data::resolve_status_id_or_unknown( 'Building' );
 
 		// Bike 1
 		$wpdb->insert(
 			$bikes_table,
 			array(
-				'last_update'     => $now,
-				'bike_image_id'   => 0,
-				'bike_name'       => 'Trail Rider',
-				'bike_desc'       => 'A reliable trail bike for weekend rides.',
-				'bike_make'       => 'Specialized',
-				'bike_model'      => 'Rockhopper',
-				'purchase_date'   => '2018-05-12 00:00:00',
-				'serial_number'   => 'DEMO-ROCK-001',
-				'bike_status_id'  => $status_active,
+				'last_update'    => $now,
+				'bike_image_id'  => 0,
+				'bike_name'      => 'Trail Rider',
+				'bike_desc'      => 'A reliable trail bike for weekend rides.',
+				'bike_make'      => 'Specialized',
+				'bike_model'     => 'Rockhopper',
+				'purchase_date'  => '2018-05-12 00:00:00',
+				'serial_number'  => 'DEMO-ROCK-001',
+				'bike_status_id' => $status_active,
 			)
 		);
 		$bike1_id = (int) $wpdb->insert_id;
@@ -80,15 +60,15 @@ class Test_Data {
 		$wpdb->insert(
 			$bikes_table,
 			array(
-				'last_update'     => $now,
-				'bike_image_id'   => 0,
-				'bike_name'       => 'Commuter',
-				'bike_desc'       => 'Everyday city and path commuting bike.',
-				'bike_make'       => 'Trek',
-				'bike_model'      => 'FX 2',
-				'purchase_date'   => '2020-03-01 00:00:00',
-				'serial_number'   => 'DEMO-TREK-002',
-				'bike_status_id'  => $status_active,
+				'last_update'    => $now,
+				'bike_image_id'  => 0,
+				'bike_name'      => 'Commuter',
+				'bike_desc'      => 'Everyday city and path commuting bike.',
+				'bike_make'      => 'Trek',
+				'bike_model'     => 'FX 2',
+				'purchase_date'  => '2020-03-01 00:00:00',
+				'serial_number'  => 'DEMO-TREK-002',
+				'bike_status_id' => $status_active,
 			)
 		);
 		$bike2_id = (int) $wpdb->insert_id;
@@ -97,15 +77,15 @@ class Test_Data {
 		$wpdb->insert(
 			$bikes_table,
 			array(
-				'last_update'     => $now,
-				'bike_image_id'   => 0,
-				'bike_name'       => 'Project Frame',
-				'bike_desc'       => 'Build in progress — demo building status.',
-				'bike_make'       => 'Surly',
-				'bike_model'      => 'Karate Monkey',
-				'purchase_date'   => '2024-01-15 00:00:00',
-				'serial_number'   => 'DEMO-SURLY-003',
-				'bike_status_id'  => $status_building ? $status_building : $status_retired,
+				'last_update'    => $now,
+				'bike_image_id'  => 0,
+				'bike_name'      => 'Project Frame',
+				'bike_desc'      => 'Build in progress — demo building status.',
+				'bike_make'      => 'Surly',
+				'bike_model'     => 'Karate Monkey',
+				'purchase_date'  => '2024-01-15 00:00:00',
+				'serial_number'  => 'DEMO-SURLY-003',
+				'bike_status_id' => $status_building ? $status_building : $status_retired,
 			)
 		);
 		$bike3_id = (int) $wpdb->insert_id;
@@ -114,31 +94,31 @@ class Test_Data {
 		$wpdb->insert(
 			$maintenance_table,
 			array(
-				'last_update'       => $now,
-				'maintenance_date'  => '2024-06-01 00:00:00',
-				'bike_id'           => $bike1_id,
-				'maintenance_desc'  => 'New chain and cassette',
-				'bike_miles'        => 1200,
+				'last_update'      => $now,
+				'maintenance_date' => '2024-06-01 00:00:00',
+				'bike_id'          => $bike1_id,
+				'maintenance_desc' => 'New chain and cassette',
+				'bike_miles'       => 1200,
 			)
 		);
 		$wpdb->insert(
 			$maintenance_table,
 			array(
-				'last_update'       => $now,
-				'maintenance_date'  => '2025-02-10 00:00:00',
-				'bike_id'           => $bike1_id,
-				'maintenance_desc'  => 'Brake pads replaced',
-				'bike_miles'        => 1850,
+				'last_update'      => $now,
+				'maintenance_date' => '2025-02-10 00:00:00',
+				'bike_id'          => $bike1_id,
+				'maintenance_desc' => 'Brake pads replaced',
+				'bike_miles'       => 1850,
 			)
 		);
 		$wpdb->insert(
 			$maintenance_table,
 			array(
-				'last_update'       => $now,
-				'maintenance_date'  => '2024-11-20 00:00:00',
-				'bike_id'           => $bike2_id,
-				'maintenance_desc'  => 'Flat tire repair',
-				'bike_miles'        => 640,
+				'last_update'      => $now,
+				'maintenance_date' => '2024-11-20 00:00:00',
+				'bike_id'          => $bike2_id,
+				'maintenance_desc' => 'Flat tire repair',
+				'bike_miles'       => 640,
 			)
 		);
 

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -395,7 +395,7 @@ function bikepress_render_demo_data_notice() {
 	<div class="notice notice-info">
 		<p>
 			<strong><?php esc_html_e( 'BikePress', 'bikepress' ); ?></strong>
-			<?php esc_html_e( 'Would you like to load sample bikes, statuses, specs, and maintenance records to explore the plugin?', 'bikepress' ); ?>
+			<?php esc_html_e( 'Would you like to load sample bikes, specs, and maintenance records to explore the plugin?', 'bikepress' ); ?>
 		</p>
 		<p>
 			<a class="button button-primary" href="<?php echo esc_url( $import_url ); ?>"><?php esc_html_e( 'Import demo data', 'bikepress' ); ?></a>
@@ -695,7 +695,7 @@ function bikepress_handle_save_status() {
 }
 
 /**
- * Delete a status, reassigning bikes to Unknown.
+ * Delete a status, reassigning bikes to Unknown only when needed.
  */
 function bikepress_handle_delete_status() {
 	if ( ! isset( $_POST['bikepress_delete_status_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['bikepress_delete_status_nonce'] ) ), 'bikepress_delete_status' ) ) {
@@ -716,18 +716,32 @@ function bikepress_handle_delete_status() {
 		bikepress_redirect_admin_page( 'status-admin', 'status_unknown_protected' );
 	}
 
-	$unknown_id = bikepress_get_or_create_unknown_status_id();
-	if ( $unknown_id <= 0 ) {
-		bikepress_redirect_admin_page( 'status-admin', 'status_delete_error' );
-	}
+	$bike_count = (int) $wpdb->get_var(
+		$wpdb->prepare(
+			'SELECT COUNT(*) FROM ' . BIKES_TABLE . ' WHERE bike_status_id = %d',
+			$status_id
+		)
+	); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
-	$wpdb->update(
-		BIKES_TABLE,
-		array( 'bike_status_id' => $unknown_id ),
-		array( 'bike_status_id' => $status_id ),
-		array( '%d' ),
-		array( '%d' )
-	);
+	if ( $bike_count > 0 ) {
+		$unknown_id = bikepress_get_or_create_unknown_status_id();
+		if ( $unknown_id <= 0 ) {
+			bikepress_redirect_admin_page( 'status-admin', 'status_delete_error' );
+		}
+
+		$wpdb->update(
+			BIKES_TABLE,
+			array( 'bike_status_id' => $unknown_id ),
+			array( 'bike_status_id' => $status_id ),
+			array( '%d' ),
+			array( '%d' )
+		);
+		$deleted = $wpdb->delete( STATUS_TABLE, array( 'id' => $status_id ), array( '%d' ) );
+		if ( false === $deleted || 0 === $deleted ) {
+			bikepress_redirect_admin_page( 'status-admin', 'status_delete_error' );
+		}
+		bikepress_redirect_admin_page( 'status-admin', 'status_deleted_reassigned' );
+	}
 
 	$deleted = $wpdb->delete( STATUS_TABLE, array( 'id' => $status_id ), array( '%d' ) );
 	if ( false === $deleted || 0 === $deleted ) {


### PR DESCRIPTION
## Summary
- Change type: Bugfix
- Version line: version1.4
- Active / Retired / Building seeded on activate as plugin data (insert-if-missing)
- Demo data is bikes/specs/maintenance only; missing status names → Unknown
- Status delete creates Unknown only when bikes use that status

## Test plan
- [ ] Fresh activate: 3 core statuses, no bikes
- [ ] Delete unused Active: no Unknown created
- [ ] Import demo with Active deleted: bikes needing Active get Unknown; Active not recreated
- [ ] Delete status in use: bikes reassigned to Unknown
- [ ] Installed and smoked-tested via `wp-bikepress-v1.4.zip`

## Notes
- Merging will be handled outside GitHub for now unless requested otherwise.