### PR TITLE
Cut plugin version 1.4.0

### DIFF
--- a/.cursor/skills/bikepress-dev/SKILL.md
+++ b/.cursor/skills/bikepress-dev/SKILL.md
@@ -200,7 +200,7 @@ Do **not** edit the deployed copy under `wp-sandbox\wp-content\plugins\...` unle
 - Workspace / git root: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress`
 - Remote: `origin` → `https://github.com/offthekitchen/wp-steves-bike-maint-plugin.git` (GitHub repo name unchanged for now)
 - Default integration branch: `main`
-- Current product version line: **1.4** (`version1.4`) in progress from `main` (1.3.0 shipped); create the next `versionX.Y` from `main` when starting a new line after release.
+- Current product version line: **1.4.0** on the `version1.4` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
 - This environment may hit `fatal: detected dubious ownership`. Prefer one-shot overrides:
 
 ```bash

--- a/docs/versions/version-1.3.md
+++ b/docs/versions/version-1.3.md
@@ -1,6 +1,6 @@
 # Version 1.3
 
-**Status:** Superseded by 1.4 (in progress)  
+**Status:** Superseded by 1.4.0  
 **Base:** main (BikePress 1.2.0)
 
 ## Summary

--- a/docs/versions/version-1.4.md
+++ b/docs/versions/version-1.4.md
@@ -1,11 +1,11 @@
 # Version 1.4
 
-**Status:** In progress  
+**Status:** Current  
 **Base:** main (BikePress 1.3.0)
 
 ## Summary
 
-Minor release line after 1.3.0: Manage Bikes media picker fix; optional demo data (bikes/specs/maint); core statuses seeded as plugin data on activate.
+Minor release **1.4.0**: Manage Bikes media picker fix; optional demo data (bikes/specs/maint); core statuses seeded as plugin data on activate.
 
 ## Changes
 
@@ -18,6 +18,10 @@ Minor release line after 1.3.0: Manage Bikes media picker fix; optional demo dat
     - Supporting Data hub card **Import Demo Data** (shared import action; blocked if bikes already exist)
     - `[bikepress-bike-list]` empty state encourages adding bikes or importing demo data
   - Why: Let real installs start clean while still offering sample data on demand
+
+- **release-1.4.0** (`version1.4-feature-release-1.4.0`): Cut plugin version 1.4.0
+  - What changed: Plugin header and `BIKEPRESS_VERSION` set to `1.4.0`
+  - Why: Ship the 1.4 line as a named WordPress plugin release
 
 ### Bugfixes
 
@@ -36,5 +40,6 @@ Minor release line after 1.3.0: Manage Bikes media picker fix; optional demo dat
 
 - Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.4.zip`
 - Unpacks to folder: `wp-bikepress/`
+- Plugins screen should show **Version 1.4.0**
 - Prefer uninstall → install → activate: 3 core statuses, no bikes; first-run notice
 - Test: delete unused status (no Unknown); demo import with deleted Active → bikes get Unknown; Select image; shortcode empty message

--- a/includes/class-bikepress.php
+++ b/includes/class-bikepress.php
@@ -70,7 +70,7 @@ class BikePress {
 		if ( defined( 'BIKEPRESS_VERSION' ) ) {
 			$this->version = BIKEPRESS_VERSION;
 		} else {
-			$this->version = '1.3.0';
+			$this->version = '1.4.0';
 		}
 		$this->plugin_name = 'bikepress';
 

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -10,7 +10,7 @@
  * Plugin Name:       BikePress
  * Plugin URI:        https://www.offthekitchen.com/wordpress-development/
  * Description:       Track bicycles, specifications, and maintenance records.
- * Version:           1.3.0
+ * Version:           1.4.0
  * Author:            Off the Kitchen
  * Author URI:        http://www.offthekitchen.com
  * License:           GPL-2.0+
@@ -25,7 +25,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'BIKEPRESS_VERSION', '1.3.0' );
+define( 'BIKEPRESS_VERSION', '1.4.0' );
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-tables.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-import-export.php';


### PR DESCRIPTION
## Summary
- Sets plugin `Version` / `BIKEPRESS_VERSION` to **1.4.0**
- Marks `version-1.4.md` as current; `version-1.3.md` superseded
- Updates skill current-version note

## Test plan
- [ ] Install `wp-bikepress-v1.4.zip` — Plugins list shows **1.4.0**
- [ ] Core statuses on activate; optional demo; Select image still works

## Notes
- After this merges to `version1.4`, open/merge `version1.4` → `main` to ship.