### PR TITLE
Cut plugin version 1.5.0

### DIFF
--- a/.cursor/skills/bikepress-dev/SKILL.md
+++ b/.cursor/skills/bikepress-dev/SKILL.md
@@ -200,7 +200,7 @@ Do **not** edit the deployed copy under `wp-sandbox\wp-content\plugins\...` unle
 - Workspace / git root: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress`
 - Remote: `origin` → `https://github.com/offthekitchen/wp-steves-bike-maint-plugin.git` (GitHub repo name unchanged for now)
 - Default integration branch: `main`
-- Current product version line: **1.4.0** on the `version1.4` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
+- Current product version line: **1.5.0** on the `version1.5` / `main` integration path after release; create the next `versionX.Y` from `main` when starting a new line.
 - This environment may hit `fatal: detected dubious ownership`. Prefer one-shot overrides:
 
 ```bash

--- a/docs/versions/version-1.4.md
+++ b/docs/versions/version-1.4.md
@@ -1,6 +1,6 @@
 # Version 1.4
 
-**Status:** Current  
+**Status:** Superseded by 1.5.0  
 **Base:** main (BikePress 1.3.0)
 
 ## Summary

--- a/docs/versions/version-1.5.md
+++ b/docs/versions/version-1.5.md
@@ -1,11 +1,11 @@
 # Version 1.5
 
-**Status:** In progress  
+**Status:** Current  
 **Base:** main (BikePress 1.4.0)
 
 ## Summary
 
-Minor release line for bike types: new type table and plugin-seeded labels, Manage Types admin, bike type on CRUD/shortcode/import-export, and schema version **1.1**.
+Minor release **1.5.0**: bike types as supporting data (schema 1.1), Manage Types admin, type on bikes/shortcode/import-export.
 
 ## Changes
 
@@ -21,9 +21,14 @@ Minor release line for bike types: new type table and plugin-seeded labels, Mana
     - `[bikepress-bike-list]` shows **TYPE** immediately before **STATUS**
   - Why: Classify bikes by type the same way statuses work, without tying types to demo data
 
+- **release-1.5.0** (`version1.5-feature-release-1.5.0`): Cut plugin version 1.5.0
+  - What changed: Plugin header and `BIKEPRESS_VERSION` set to `1.5.0`
+  - Why: Ship the 1.5 line as a named WordPress plugin release
+
 ## Install / test notes
 
 - Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.5.zip`
 - Unpacks to folder: `wp-bikepress/`
+- Plugins screen should show **Version 1.5.0**
 - After activate/upgrade: core types present; existing bikes without a type get Unknown
 - Test: Manage Types CRUD; set type on a bike; shortcode TYPE line; export JSON; import a 1.0 export if available

--- a/includes/class-bikepress.php
+++ b/includes/class-bikepress.php
@@ -70,7 +70,7 @@ class BikePress {
 		if ( defined( 'BIKEPRESS_VERSION' ) ) {
 			$this->version = BIKEPRESS_VERSION;
 		} else {
-			$this->version = '1.4.0';
+			$this->version = '1.5.0';
 		}
 		$this->plugin_name = 'bikepress';
 

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -10,7 +10,7 @@
  * Plugin Name:       BikePress
  * Plugin URI:        https://www.offthekitchen.com/wordpress-development/
  * Description:       Track bicycles, specifications, and maintenance records.
- * Version:           1.4.0
+ * Version:           1.5.0
  * Author:            Off the Kitchen
  * Author URI:        http://www.offthekitchen.com
  * License:           GPL-2.0+
@@ -25,7 +25,7 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'BIKEPRESS_VERSION', '1.4.0' );
+define( 'BIKEPRESS_VERSION', '1.5.0' );
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-tables.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-bikepress-import-export.php';


### PR DESCRIPTION
## Summary
- Change type: Feature
- Version line: version1.5
- Bumps plugin header and `BIKEPRESS_VERSION` to **1.5.0**
- Marks version 1.5 docs Current; 1.4 Superseded; updates skill current-version note

## Test plan
- [ ] Plugins screen shows **Version 1.5.0**
- [ ] Installed and smoked-tested via `wp-bikepress-v1.5.zip`
- [ ] Manage Types / bike type / shortcode TYPE still work

## Notes
- After merge to `version1.5`, open/merge `version1.5` → `main` to ship on the default branch (same as 1.4).
- Merging will be handled outside GitHub for now unless requested otherwise.