### PR TITLE
Widen bike field limits and list UX polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ wp-config.php
 # Note: If you wish to whitelist themes,
 # uncomment the next line
 #/wp-content/themes
+assets

--- a/admin/partials/bikes-admin-page.php
+++ b/admin/partials/bikes-admin-page.php
@@ -43,14 +43,18 @@ if ( 'edit' === $action || 'delete' === $action ) {
 
 $notice = isset( $_GET['bikepress_notice'] ) ? sanitize_key( wp_unslash( $_GET['bikepress_notice'] ) ) : '';
 $notice_messages = array(
-	'bike_created'         => array( 'success', __( 'Bike created.', 'bikepress' ) ),
-	'bike_updated'         => array( 'success', __( 'Bike updated.', 'bikepress' ) ),
-	'bike_deleted'         => array( 'success', __( 'Bike and related specs/maintenance deleted.', 'bikepress' ) ),
-	'bike_save_error'      => array( 'error', __( 'Could not save the bike.', 'bikepress' ) ),
-	'bike_delete_error'    => array( 'error', __( 'Could not delete the bike.', 'bikepress' ) ),
-	'bike_name_required'   => array( 'error', __( 'Bike name is required.', 'bikepress' ) ),
-	'bike_status_required' => array( 'error', __( 'Please choose a status.', 'bikepress' ) ),
-	'bike_type_required'   => array( 'error', __( 'Please choose a type.', 'bikepress' ) ),
+	'bike_created'           => array( 'success', __( 'Bike created.', 'bikepress' ) ),
+	'bike_updated'           => array( 'success', __( 'Bike updated.', 'bikepress' ) ),
+	'bike_deleted'           => array( 'success', __( 'Bike and related specs/maintenance deleted.', 'bikepress' ) ),
+	'bike_save_error'        => array( 'error', __( 'Could not save the bike.', 'bikepress' ) ),
+	'bike_delete_error'      => array( 'error', __( 'Could not delete the bike.', 'bikepress' ) ),
+	'bike_name_required'     => array( 'error', __( 'Bike name is required.', 'bikepress' ) ),
+	'bike_status_required'   => array( 'error', __( 'Please choose a status.', 'bikepress' ) ),
+	'bike_type_required'     => array( 'error', __( 'Please choose a type.', 'bikepress' ) ),
+	'bike_make_too_long'     => array( 'error', __( 'Make cannot be longer than 15 characters.', 'bikepress' ) ),
+	'bike_model_too_long'    => array( 'error', __( 'Model cannot be longer than 50 characters.', 'bikepress' ) ),
+	'bike_serial_too_long'   => array( 'error', __( 'Serial number cannot be longer than 50 characters.', 'bikepress' ) ),
+	'bike_field_too_long'    => array( 'error', __( 'One or more fields are too long for the database. Shorten make (15), model (50), or serial number (50) and try again.', 'bikepress' ) ),
 );
 
 $default_image = plugins_url( 'img/default-bike.jpg', dirname( dirname( __FILE__ ) ) . '/wp-bikepress.php' );
@@ -154,15 +158,24 @@ if ( $form_image_id > 0 ) {
 					</tr>
 					<tr>
 						<th scope="row"><label for="bike_make"><?php esc_html_e( 'Make', 'bikepress' ); ?></label></th>
-						<td><input name="bike_make" id="bike_make" type="text" class="regular-text" value="<?php echo esc_attr( $form_make ); ?>" /></td>
+						<td>
+							<input name="bike_make" id="bike_make" type="text" class="regular-text" maxlength="15" value="<?php echo esc_attr( $form_make ); ?>" />
+							<p class="description"><?php esc_html_e( 'Maximum 15 characters.', 'bikepress' ); ?></p>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row"><label for="bike_model"><?php esc_html_e( 'Model', 'bikepress' ); ?></label></th>
-						<td><input name="bike_model" id="bike_model" type="text" class="regular-text" value="<?php echo esc_attr( $form_model ); ?>" /></td>
+						<td>
+							<input name="bike_model" id="bike_model" type="text" class="regular-text" maxlength="50" value="<?php echo esc_attr( $form_model ); ?>" />
+							<p class="description"><?php esc_html_e( 'Maximum 50 characters.', 'bikepress' ); ?></p>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row"><label for="serial_number"><?php esc_html_e( 'Serial number', 'bikepress' ); ?></label></th>
-						<td><input name="serial_number" id="serial_number" type="text" class="regular-text" value="<?php echo esc_attr( $form_serial ); ?>" /></td>
+						<td>
+							<input name="serial_number" id="serial_number" type="text" class="regular-text" maxlength="50" value="<?php echo esc_attr( $form_serial ); ?>" />
+							<p class="description"><?php esc_html_e( 'Maximum 50 characters.', 'bikepress' ); ?></p>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row"><label for="bike_type_id"><?php esc_html_e( 'Type', 'bikepress' ); ?></label></th>
@@ -196,7 +209,10 @@ if ( $form_image_id > 0 ) {
 					</tr>
 					<tr>
 						<th scope="row"><label for="bike_desc"><?php esc_html_e( 'Description', 'bikepress' ); ?></label></th>
-						<td><textarea name="bike_desc" id="bike_desc" class="large-text" rows="5"><?php echo esc_textarea( $form_desc ); ?></textarea></td>
+						<td>
+							<textarea name="bike_desc" id="bike_desc" class="large-text" rows="5"><?php echo esc_textarea( $form_desc ); ?></textarea>
+							<p class="description"><?php esc_html_e( 'Longer descriptions are supported.', 'bikepress' ); ?></p>
+						</td>
 					</tr>
 					<tr>
 						<th scope="row"><?php esc_html_e( 'Image', 'bikepress' ); ?></th>

--- a/docs/versions/version-1.6.md
+++ b/docs/versions/version-1.6.md
@@ -1,0 +1,34 @@
+# Version 1.6
+
+**Status:** In progress  
+**Base:** main (BikePress 1.5.0)
+
+## Summary
+
+Minor release line for Manage Bikes field-limit fixes / shortcode list polish, and (planned) PDF bike reports.
+
+## Changes
+
+### Bugfixes
+
+- **bike-field-limits** (`version1.6-bugfix-bike-field-limits`): Widen bike fields and clarify save errors
+  - What was wrong:
+    - Long descriptions failed to save (`bike_desc` was `varchar(255)`) with a generic error
+    - Model and serial were too short (`varchar(15)` / `varchar(30)`)
+  - What fixed it:
+    - `bike_desc` → `TEXT`; model and serial → `varchar(50)`; `bikepress_db_version` → **1.2**
+    - Server-side length checks and clearer notices; form `maxlength` hints
+    - Specs list header **NAME** → **SPEC**
+    - Phone: Make/Model/Type/Status stack in a column
+    - Desktop: descriptions longer than 64 characters use **more...** / **less...**; card grows, photo size unchanged
+
+### Features
+
+- **bike-pdf-reports** (`version1.6-feature-bike-pdf-reports`): *(planned)* My Bikes Reports card and printable PDF (summary/specs + maintenance log)
+
+## Install / test notes
+
+- Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.6.zip`
+- Unpacks to folder: `wp-bikepress/`
+- After upgrade: long descriptions save; model/serial up to 50 chars
+- Test shortcode: SPEC header; mobile stacked details; desktop more/less on long descriptions

--- a/includes/class-bikepress-activator.php
+++ b/includes/class-bikepress-activator.php
@@ -19,7 +19,7 @@
  */
 class BikePress_Activator {
 
-	const DB_VERSION = '1.1';
+	const DB_VERSION = '1.2';
 
 	/**
 	 * Create or upgrade tables; seed plugin data; optionally load demo data.
@@ -80,10 +80,10 @@ class BikePress_Activator {
 			bike_image_id mediumint(9) DEFAULT 0 NOT NULL,
 			last_update datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
 			bike_name tinytext NOT NULL,
-			bike_desc varchar(255) DEFAULT '' NOT NULL,
+			bike_desc text NOT NULL,
 			bike_make varchar(15) DEFAULT '' NOT NULL,
-			bike_model varchar(15) DEFAULT '' NOT NULL,
-			serial_number varchar(30) DEFAULT '' NOT NULL,
+			bike_model varchar(50) DEFAULT '' NOT NULL,
+			serial_number varchar(50) DEFAULT '' NOT NULL,
 			purchase_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
 			bike_status_id mediumint(9) NOT NULL,
 			bike_type_id mediumint(9) DEFAULT 0 NOT NULL,

--- a/includes/class-bikepress-import-export.php
+++ b/includes/class-bikepress-import-export.php
@@ -23,13 +23,13 @@ class BikePress_Import_Export {
 	 */
 	public static function current_db_version() {
 		$version = get_option( 'bikepress_db_version', '' );
-		return $version ? (string) $version : '1.1';
+		return $version ? (string) $version : '1.2';
 	}
 
 	/**
 	 * Whether a file db_version can be imported into the current schema.
 	 *
-	 * Accepts exact match, or legacy 1.0 into current 1.1 (missing types → Unknown).
+	 * Accepts exact match, or older schemas (1.0 / 1.1) into newer sites.
 	 *
 	 * @param string $file_version Export db_version.
 	 * @param string $current      Site db_version.
@@ -47,8 +47,8 @@ class BikePress_Import_Export {
 			return true;
 		}
 
-		// Older 1.0 exports (no types) are accepted on 1.1 sites.
-		if ( '1.0' === $file_version && '1.1' === $current ) {
+		// Older exports are accepted on newer sites (types added in 1.1; wider columns in 1.2).
+		if ( version_compare( $file_version, '1.0', '>=' ) && version_compare( $file_version, $current, '<' ) ) {
 			return true;
 		}
 
@@ -126,7 +126,7 @@ class BikePress_Import_Export {
 		}
 
 		$data = $doc['data'];
-		$legacy_no_types = ( '1.0' === $file_version && '1.1' === $current );
+		$legacy_no_types = version_compare( $file_version, '1.1', '<' );
 
 		$stats = array(
 			'statuses'    => array( 'inserted' => 0, 'updated' => 0, 'errors' => 0 ),

--- a/public/css/bikepress-public.css
+++ b/public/css/bikepress-public.css
@@ -45,12 +45,21 @@
 
 .bike {
     display: flex;
+    align-items: flex-start;
     margin-top: 33px;
     height: 200px;
     background-color: white;
     border-radius: 20px;
     padding: 5px;
     filter: drop-shadow(0px 3px 15px rgba(0, 0, 0, 0.1));
+    overflow: hidden;
+    box-sizing: border-box;
+}
+
+.bike.bike-desc-expanded {
+    height: auto;
+    min-height: 200px;
+    overflow: visible;
 }
 
 .bike-title {
@@ -58,6 +67,7 @@
 }
 
 .bike-image {
+    flex: 0 0 200px;
     height: 200px;
     width: 200px;
     border-top-left-radius: 20px;
@@ -68,6 +78,24 @@
 .bike-info {
     margin: 5px 15px;
     width: 100%;
+    min-width: 0;
+}
+
+.bike-desc-full {
+    display: none;
+}
+
+.bike-desc.is-expanded .bike-desc-short {
+    display: none;
+}
+
+.bike-desc.is-expanded .bike-desc-full {
+    display: inline;
+}
+
+.bike-desc-toggle {
+    white-space: nowrap;
+    margin-left: 4px;
 }
 
 .bike-entries {
@@ -147,9 +175,11 @@
     .bike {
       display: block;
       height: fit-content;
+      overflow: visible;
     }
 
     .bike-image {
+        flex: none;
         height: 200px;
         width: 100%;
         border-top-right-radius: 20px;
@@ -160,9 +190,28 @@
         margin: 0;
     }
 
+    /* Phone: always show full description; hide truncate UI. */
+    .bike-desc-short,
+    .bike-desc-toggle {
+        display: none !important;
+    }
+
+    .bike-desc-full {
+        display: inline !important;
+    }
+
     .bike-header {
         display: block;
         max-height: fit-content;
+    }
+
+    .bike-specs {
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .bike-detail {
+        margin: 0;
     }
 
     .bike-section-header {

--- a/public/js/bikepress-public.js
+++ b/public/js/bikepress-public.js
@@ -1,5 +1,5 @@
 /**
- * Displays a particular section for a given bike 
+ * Displays a particular section for a given bike
  *
  * @param {string} sectionName - the name of the section to be displayed
  * @param {number} bikeId - the ID of the bike being displayed
@@ -16,24 +16,24 @@ showSection = (sectionName, bikeId, bikeName) => {
 	const noRecords = document.getElementsByClassName('no-records')
 	const maintTitleBikeName = document.getElementById('maintenance-log-bike-name')
 	const specsTitleBikeName = document.getElementById('specs-list-bike-name')
-  
+
 	if (sectionName != 'bikes') {
 	  // Hide all entries
 	  for (let i = 0; i < entryRecords.length; i++) {
 		entryRecords[i].style.display = 'none'
 	  }
-  
+
 	  // Hide the No Records messages
 	  for (let i = 0; i < noRecords.length; i++) {
 		noRecords[i].style.visibility = 'hidden'
 	  }
-  
+
 	  // Show all the records for this bike
 	  for (let i = 0; i < bikeRecords.length; i++) {
 		bikeRecords[i].style.display = 'flex'
 	  }
 	}
-  
+
 	switch (sectionName) {
 	  case 'maintenance':
 		bikeList.style.display = 'none'
@@ -59,8 +59,8 @@ showSection = (sectionName, bikeId, bikeName) => {
 	  default:
 		console.error('NO SECTION NAME')
 	}
-  
-	// After the appropriate records are hidden and displayed, use visibility to determine if there are records showing 
+
+	// After the appropriate records are hidden and displayed, use visibility to determine if there are records showing
 	if (sectionName != 'bikes') {
 	  if (checkForVisibleRecords(bikeRecords, sectionName)) {
 		for (var i = 0; i < noRecords.length; i++) {
@@ -73,13 +73,13 @@ showSection = (sectionName, bikeId, bikeName) => {
 	  }
 	}
   }
-  
+
   /**
    * Checks if there are any records visible for a specific section
    *
    * @param {array} records - all records for all bikes
    * @param {string} sectionName - the name of the section in question
-   * @returns {boolean} 
+   * @returns {boolean}
    */
   checkForVisibleRecords = (records, sectionName) => {
 	let entryClass = ''
@@ -106,3 +106,26 @@ showSection = (sectionName, bikeId, bikeName) => {
 	}
 	return false
   }
+
+/**
+ * Desktop: expand/collapse long bike descriptions (more... / less...).
+ */
+document.addEventListener('click', function (event) {
+	const toggle = event.target.closest('.bike-desc-toggle')
+	if (!toggle) {
+		return
+	}
+
+	event.preventDefault()
+
+	const desc = toggle.closest('.bike-desc')
+	const card = toggle.closest('.bike')
+	if (!desc || !card) {
+		return
+	}
+
+	const expanded = desc.classList.toggle('is-expanded')
+	card.classList.toggle('bike-desc-expanded', expanded)
+	toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false')
+	toggle.textContent = expanded ? 'less...' : 'more...'
+})

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -226,6 +226,20 @@ function bikepress_handle_save_bike() {
 		bikepress_redirect_bikes_admin( 'bike_type_required', array( 'action' => $bike_id ? 'edit' : 'new', 'bike_id' => $bike_id ) );
 	}
 
+	$make_len   = function_exists( 'mb_strlen' ) ? mb_strlen( $bike_make, 'UTF-8' ) : strlen( $bike_make );
+	$model_len  = function_exists( 'mb_strlen' ) ? mb_strlen( $bike_model, 'UTF-8' ) : strlen( $bike_model );
+	$serial_len = function_exists( 'mb_strlen' ) ? mb_strlen( $serial_number, 'UTF-8' ) : strlen( $serial_number );
+
+	if ( $make_len > 15 ) {
+		bikepress_redirect_bikes_admin( 'bike_make_too_long', array( 'action' => $bike_id ? 'edit' : 'new', 'bike_id' => $bike_id ) );
+	}
+	if ( $model_len > 50 ) {
+		bikepress_redirect_bikes_admin( 'bike_model_too_long', array( 'action' => $bike_id ? 'edit' : 'new', 'bike_id' => $bike_id ) );
+	}
+	if ( $serial_len > 50 ) {
+		bikepress_redirect_bikes_admin( 'bike_serial_too_long', array( 'action' => $bike_id ? 'edit' : 'new', 'bike_id' => $bike_id ) );
+	}
+
 	$purchase_date = '0000-00-00 00:00:00';
 	if ( $purchase_raw && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $purchase_raw ) ) {
 		$purchase_date = $purchase_raw . ' 00:00:00';
@@ -255,16 +269,36 @@ function bikepress_handle_save_bike() {
 			array( '%d' )
 		);
 		if ( false === $updated ) {
-			bikepress_redirect_bikes_admin( 'bike_save_error', array( 'action' => 'edit', 'bike_id' => $bike_id ) );
+			bikepress_redirect_bikes_admin(
+				bikepress_bike_save_error_notice( $wpdb ),
+				array( 'action' => 'edit', 'bike_id' => $bike_id )
+			);
 		}
 		bikepress_redirect_bikes_admin( 'bike_updated' );
 	}
 
 	$inserted = $wpdb->insert( BIKES_TABLE, $row, $formats );
 	if ( false === $inserted ) {
-		bikepress_redirect_bikes_admin( 'bike_save_error', array( 'action' => 'new' ) );
+		bikepress_redirect_bikes_admin(
+			bikepress_bike_save_error_notice( $wpdb ),
+			array( 'action' => 'new' )
+		);
 	}
 	bikepress_redirect_bikes_admin( 'bike_created' );
+}
+
+/**
+ * Map a failed bike save to a clearer notice slug when possible.
+ *
+ * @param wpdb $wpdb WordPress DB object after a failed write.
+ * @return string Notice slug.
+ */
+function bikepress_bike_save_error_notice( $wpdb ) {
+	$error = isset( $wpdb->last_error ) ? (string) $wpdb->last_error : '';
+	if ( $error && false !== stripos( $error, 'Data too long' ) ) {
+		return 'bike_field_too_long';
+	}
+	return 'bike_save_error';
 }
 
 /**
@@ -1201,7 +1235,23 @@ function bikepress_bike_list( $atts ) {
 		$Content .= '<div class="bike-type bike-detail"><b>TYPE:</b> ' . esc_html( $bike_type_label ) . '</div>';
 		$Content .= '<div class="bike-status bike-detail"><b>STATUS:</b> ' . esc_html( $oBike->bike_status ) . '</div>';
 		$Content .= '</div>';
-		$Content .= '<div class="bike-data"><div class="bike-desc">' . esc_html( $oBike->bike_desc ) . '</div></div>';
+
+		$desc_raw   = (string) $oBike->bike_desc;
+		$desc_limit = 64;
+		$desc_len   = function_exists( 'mb_strlen' ) ? mb_strlen( $desc_raw, 'UTF-8' ) : strlen( $desc_raw );
+		$desc_short = $desc_len > $desc_limit
+			? ( function_exists( 'mb_substr' ) ? mb_substr( $desc_raw, 0, $desc_limit, 'UTF-8' ) : substr( $desc_raw, 0, $desc_limit ) )
+			: $desc_raw;
+
+		$Content .= '<div class="bike-data"><div class="bike-desc' . ( $desc_len > $desc_limit ? ' bike-desc-truncatable' : '' ) . '">';
+		if ( $desc_len > $desc_limit ) {
+			$Content .= '<span class="bike-desc-short">' . esc_html( $desc_short ) . '</span>';
+			$Content .= '<span class="bike-desc-full">' . esc_html( $desc_raw ) . '</span>';
+			$Content .= ' <a href="#" class="bike-desc-toggle" aria-expanded="false">' . esc_html__( 'more...', 'bikepress' ) . '</a>';
+		} else {
+			$Content .= '<span class="bike-desc-full">' . esc_html( $desc_raw ) . '</span>';
+		}
+		$Content .= '</div></div>';
 		$Content .= '</div></article>';
 	}
 	$Content .= '</section>';
@@ -1252,7 +1302,7 @@ function bikepress_bike_list( $atts ) {
 	$Content .= '</div></div>';
 
 	$Content .= '<div class="spec-entries bike-entries">';
-	$Content .= '<header class="spec-entry-headers entry-headers"><div class="col">NAME</div><div class="col">DESC</div></header>';
+	$Content .= '<header class="spec-entry-headers entry-headers"><div class="col">SPEC</div><div class="col">DESC</div></header>';
 
 	foreach ( $aBikes as $oBike ) {
 		$Content .= '<div class="entry-record spec-entry row bike-' . absint( $oBike->id ) . '">';


### PR DESCRIPTION
## Summary
- Change type: Bugfix
- Version line: version1.6
- Widens `bike_desc` to TEXT; model/serial to 50 chars; db schema **1.2**
- Clearer save length errors; form maxlength hints
- Specs header NAME → SPEC; mobile stacks Make/Model/Type/Status; desktop more/less for long descriptions

## Test plan
- [ ] Long description saves after upgrade
- [ ] Model/serial 50 chars OK; over-limit shows clear message
- [ ] Shortcode SPEC header; mobile stacked details; desktop more/less
- [ ] Installed via `wp-bikepress-v1.6.zip`

## Notes
- Merging will be handled outside GitHub for now unless requested otherwise.