### PR TITLE
Fix blurry shortcode bike photos

### DIFF
--- a/docs/versions/version-1.6.md
+++ b/docs/versions/version-1.6.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Minor release line for Manage Bikes field-limit fixes / shortcode list polish, and PDF bike reports.
+Minor release line for Manage Bikes field-limit fixes / shortcode list polish, PDF bike reports, and shortcode image clarity.
 
 ## Changes
 
@@ -21,6 +21,12 @@ Minor release line for Manage Bikes field-limit fixes / shortcode list polish, a
     - Specs list header **NAME** → **SPEC**
     - Phone: Make/Model/Type/Status stack in a column
     - Desktop: descriptions longer than 64 characters use **more...** / **less...**; card grows, photo size unchanged
+
+- **shortcode-bike-image-clarity** (`version1.6-bugfix-shortcode-bike-image-clarity`): Sharper bike photos on the public list
+  - What was wrong:
+    - Shortcode used WordPress `'thumbnail'` (often 150×150) while CSS displays at ~200×200, so images looked blurry
+  - What fixed it:
+    - Request `'medium'` from `wp_get_attachment_image_src` (same as Manage Bikes admin)
 
 ### Features
 
@@ -39,5 +45,5 @@ Minor release line for Manage Bikes field-limit fixes / shortcode list polish, a
 - Zip: `C:\Data\Web Sites\plugins\wp-steves-bike-maint-plugin\wp-bikepress-v1.6.zip`
 - Unpacks to folder: `wp-bikepress/`
 - After upgrade: long descriptions save; model/serial up to 50 chars; Reports available from My Bikes and the admin submenu
-- Test shortcode: SPEC header; mobile stacked details; desktop more/less on long descriptions
+- Test shortcode: SPEC header; mobile stacked details; desktop more/less on long descriptions; bike photos look sharp at card size
 - Test Reports: pick a bike with photo, description, specs, and maintenance; download PDF and check summary + log layout, pagination, and footer

--- a/wp-bikepress.php
+++ b/wp-bikepress.php
@@ -1277,7 +1277,7 @@ function bikepress_bike_list( $atts ) {
 
 		$Content .= '<article class="bike bike-data">';
 
-		$image_attributes = wp_get_attachment_image_src( absint( $oBike->bike_image_id ) );
+		$image_attributes = wp_get_attachment_image_src( absint( $oBike->bike_image_id ), 'medium' );
 		if ( $image_attributes ) {
 			$Content .= sprintf(
 				'<img src="%s" width="%d" height="%d" class="bike-image" alt="%s" />',


### PR DESCRIPTION
## Summary
- Change type: Bugfix
- Shortcode bike list now requests the WordPress `medium` attachment size instead of the default `thumbnail`
- Stops upscaling ~150px thumbs into the ~200px card slot so photos look sharp like Manage Bikes admin

## Test plan
- [ ] Install `wp-bikepress-v1.6.zip` on the sandbox
- [ ] Open `[bikepress-bike-list]` and confirm bike photos look clear at card size
- [ ] Confirm default image still works when no attachment is set
- [ ] Spot-check mobile full-width photo and Manage Bikes admin preview unchanged

Made with [Cursor](https://cursor.com)